### PR TITLE
"entrySet()" should be iterated when both the key and value are needed

### DIFF
--- a/core/ast/src/main/java/org/overture/ast/lex/LexLocation.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexLocation.java
@@ -378,13 +378,13 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 	{
 		LexNameList list = new LexNameList();
 
-		for (LexNameToken name : nameSpans.keySet())
+		for (Map.Entry<LexNameToken, LexLocation> entry : nameSpans.entrySet())
 		{
-			LexLocation span = nameSpans.get(name);
+			LexLocation span = entry.getValue();
 
 			if (span.file.equals(filename))
 			{
-				list.add(name);
+				list.add(entry.getKey());
 			}
 		}
 

--- a/core/ast/src/main/java/org/overture/ast/lex/LexLocationUtils.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexLocationUtils.java
@@ -120,13 +120,13 @@ public class LexLocationUtils implements Serializable
 	{
 		LexNameList list = new LexNameList();
 
-		for (LexNameToken name : nameSpans.keySet())
+		for (Map.Entry<LexNameToken, ILexLocation> entry : nameSpans.entrySet())
 		{
-			ILexLocation span = nameSpans.get(name);
+			ILexLocation span = entry.getValue();
 
 			if (span.getFile().equals(filename))
 			{
-				list.add(name);
+				list.add(entry.getKey());
 			}
 		}
 

--- a/core/codegen/codegen-maven-plugin/src/main/java/org/overture/codegen/mojocg/Vdm2JavaMojo.java
+++ b/core/codegen/codegen-maven-plugin/src/main/java/org/overture/codegen/mojocg/Vdm2JavaMojo.java
@@ -216,9 +216,9 @@ public class Vdm2JavaMojo extends Vdm2JavaBaseMojo
 			
 			getLog().info("Found following bridge/delegate pairs:");
 			
-			for(String entry : delegateMap.keySet())
+			for(Map.Entry<String, String> entry : delegateMap.entrySet())
 			{
-				getLog().info("  Bridge class: " + entry + ". Delegate class: " + delegateMap.get(entry));
+				getLog().info("  Bridge class: " + entry.getKey() + ". Delegate class: " + entry.getValue());
 			}
 			
 			javaCodeGen.getTransSeries().getSeries().add(new DelegateTrans(delegateMap, javaCodeGen.getTransAssistant(), getLog()));

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/MapUtil.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/MapUtil.java
@@ -22,6 +22,7 @@
 package org.overture.codegen.runtime;
 
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Set;
 
 public class MapUtil
@@ -40,11 +41,11 @@ public class MapUtil
 		Maplet[] maplets = new Maplet[vdmMap.size()];
 
 		int nextIndex = 0;
-		for (Object key : vdmMap.keySet())
+		for (Object o : vdmMap.entrySet())
 		{
-			Object val = vdmMap.get(key);
+			Object val = ((Map.Entry) o).getValue();
 
-			maplets[nextIndex++] = new Maplet(key, val);
+			maplets[nextIndex++] = new Maplet(((Map.Entry) o).getKey(), val);
 		}
 
 		return maplets;
@@ -212,12 +213,12 @@ public class MapUtil
 
 		VDMMap result = map();
 
-		for (Object key : vdmMap.keySet())
+		for (Object o : vdmMap.entrySet())
 		{
-			if (!vdmDom.contains(key))
+			if (!vdmDom.contains(((Map.Entry) o).getKey()))
 			{
-				Object value = vdmMap.get(key);
-				result.put(key, value);
+				Object value = ((Map.Entry) o).getValue();
+				result.put(((Map.Entry) o).getKey(), value);
 			}
 		}
 
@@ -240,13 +241,13 @@ public class MapUtil
 		@SuppressWarnings("rawtypes")
 		Set dom = vdmMap.keySet();
 
-		for (Object key : dom)
+		for (Object o : vdmMap.entrySet())
 		{
-			Object value = vdmMap.get(key);
+			Object value = ((Map.Entry) o).getValue();
 
 			if (vdmRng.contains(value))
 			{
-				result.put(key, value);
+				result.put(((Map.Entry) o).getKey(), value);
 			}
 		}
 
@@ -266,13 +267,13 @@ public class MapUtil
 
 		VDMMap result = map();
 
-		for (Object key : vdmMap.keySet())
+		for (Object o : vdmMap.entrySet())
 		{
-			Object value = vdmMap.get(key);
+			Object value = ((Map.Entry) o).getValue();
 
 			if (!vdmRng.contains(value))
 			{
-				result.put(key, value);
+				result.put(((Map.Entry) o).getKey(), value);
 			}
 		}
 
@@ -365,18 +366,18 @@ public class MapUtil
 		@SuppressWarnings("rawtypes")
 		Set fromKeys = from.keySet();
 
-		for (Object fromKey : fromKeys)
+		for (Object o : from.entrySet())
 		{
-			Object fromVal = from.get(fromKey);
+			Object fromVal = ((Map.Entry) o).getValue();
 
-			if (to.containsKey(fromKey))
+			if (to.containsKey(((Map.Entry) o).getKey()))
 			{
-				Object toVal = to.get(fromKey);
+				Object toVal = to.get(((Map.Entry) o).getKey());
 				if (differentValues(toVal, fromVal))
 					throw new IllegalAccessError("Duplicate keys that have different values are not allowed");
 			}
 
-			to.put(fromKey, fromVal);
+			to.put(((Map.Entry) o).getKey(), fromVal);
 		}
 	}
 

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/ModuleCopy.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/ModuleCopy.java
@@ -50,15 +50,15 @@ public class ModuleCopy
 			return;
 		}
 		
-		for (Field f : staticFields.keySet())
+		for (Map.Entry<Field, Object> entry : staticFields.entrySet())
 		{
-			f.setAccessible(true);
+			entry.getKey().setAccessible(true);
 	
-			Object v = deepCopy(staticFields.get(f));
+			Object v = deepCopy(entry.getValue());
 	
 			try
 			{
-				f.set(null, v);
+				entry.getKey().set(null, v);
 			} catch (IllegalArgumentException | IllegalAccessException e)
 			{
 				e.printStackTrace();

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/Store.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/Store.java
@@ -31,9 +31,9 @@ public class Store
 	
 	public void reset()
 	{
-		for(Number k : values.keySet())
+		for(Map.Entry<Number, ModuleCopy> entry : values.entrySet())
 		{
-			values.get(k).reset();
+			entry.getValue().reset();
 		}
 	}
 	
@@ -45,12 +45,12 @@ public class Store
 		
 		String sep = "";
 		
-		for(Number k : values.keySet())
+		for(Map.Entry<Number, ModuleCopy> entry : values.entrySet())
 		{
 			sb.append(sep);
-			sb.append(Utils.toString(k));
+			sb.append(Utils.toString(entry.getKey()));
 			sb.append(" |-> ");
-			sb.append(Utils.toString(values.get(k)));
+			sb.append(Utils.toString(entry.getValue()));
 			sep = ", ";
 		}
 		

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/ComparisonIR.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/ComparisonIR.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.lang.reflect.Field;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import org.overture.ast.intf.lex.ILexNameToken;
@@ -252,11 +253,11 @@ public class ComparisonIR
 		{
 			boolean foundMatchingField = false;
 
-			for (ILexNameToken tok : keySet)
+			for (Map.Entry<ILexNameToken, Value> entry : memberValues.entrySet())
 			{
-				if (field.getName().equals(tok.getName()))
+				if (field.getName().equals(entry.getKey().getName()))
 				{
-					Value vdmFieldValue = memberValues.get(tok);
+					Value vdmFieldValue = entry.getValue();
 
 					if (vdmFieldValue != null)
 					{
@@ -490,14 +491,14 @@ public class ComparisonIR
 			return false;
 		}
 
-		for (Object cgKey : cgMap.keySet())
+		for (Object o : cgMap.entrySet())
 		{
 			boolean match = false;
 			for (Value vdmKey : vdmMap.values.keySet())
 			{
-				if (compare(cgKey, vdmKey))
+				if (compare(((Map.Entry) o).getKey(), vdmKey))
 				{
-					Object cgVal = cgMap.get(cgKey);
+					Object cgVal = ((Map.Entry) o).getValue();
 					Value vdmVal = vdmMap.values.get(vdmKey);
 
 					if (compare(cgVal, vdmVal))

--- a/core/codegen/platform/src/main/java/org/overture/codegen/assistant/LocationAssistantIR.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/assistant/LocationAssistantIR.java
@@ -48,9 +48,9 @@ public class LocationAssistantIR extends AssistantBase
 
 		Set<String> allKeys = children.keySet();
 
-		for (String key : allKeys)
+		for (Map.Entry<String, Object> entry : children.entrySet())
 		{
-			Object child = children.get(key);
+			Object child = entry.getValue();
 
 			if (child instanceof ILexLocation)
 			{

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/data/StateDesInfo.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/data/StateDesInfo.java
@@ -57,9 +57,9 @@ public class StateDesInfo
 	
 	public boolean isStateDesDecl(AVarDeclIR decl)
 	{
-		for (SStmIR stm : stateDesDecls.keySet())
+		for (Map.Entry<SStmIR, List<AVarDeclIR>> entry : stateDesDecls.entrySet())
 		{
-			List<AVarDeclIR> decls = stateDesDecls.get(stm);
+			List<AVarDeclIR> decls = entry.getValue();
 			
 			if(decls != null)
 			{
@@ -84,13 +84,13 @@ public class StateDesInfo
 	
 	public ADefaultClassDeclIR getEnclosingClass(AIdentifierVarExpIR stateDesVar)
 	{
-		for(SStmIR k : stateDesVars.keySet())
+		for(Map.Entry<SStmIR, List<AIdentifierVarExpIR>> entry : stateDesVars.entrySet())
 		{
-			for(AIdentifierVarExpIR v : stateDesVars.get(k))
+			for(AIdentifierVarExpIR v : entry.getValue())
 			{
 				if(v == stateDesVar)
 				{
-					ADefaultClassDeclIR encClass = k.getAncestor(ADefaultClassDeclIR.class);
+					ADefaultClassDeclIR encClass = entry.getKey().getAncestor(ADefaultClassDeclIR.class);
 					
 					if (encClass == null)
 					{

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceRunnerMain.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceRunnerMain.java
@@ -590,9 +590,9 @@ public class TraceRunnerMain implements IProgressMonitor
 			System.err.println("Default = " + Charset.defaultCharset());
 			Map<String, Charset> available = Charset.availableCharsets();
 
-			for (String name : available.keySet())
+			for (Map.Entry<String, Charset> entry : available.entrySet())
 			{
-				System.err.println(name + " " + available.get(name).aliases());
+				System.err.println(entry.getKey() + " " + entry.getValue().aliases());
 			}
 
 			System.err.println("");

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/xml/XMLOpenTagNode.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/xml/XMLOpenTagNode.java
@@ -24,6 +24,7 @@
 package org.overture.ct.ctruntime.server.xml;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 public class XMLOpenTagNode extends XMLTagNode
@@ -75,12 +76,12 @@ public class XMLOpenTagNode extends XMLTagNode
 		sb.append("<");
 		sb.append(tag);
 
-		for (Object name : attrs.keySet())
+		for (Map.Entry<Object, Object> entry : attrs.entrySet())
 		{
 			sb.append(" ");
-			sb.append(name);
+			sb.append(entry.getKey());
 			sb.append("=\"");
-			sb.append(attrs.get(name));
+			sb.append(entry.getValue());
 			sb.append("\"");
 		}
 

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/xml/XMLTagNode.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/xml/XMLTagNode.java
@@ -23,6 +23,7 @@
 
 package org.overture.ct.ctruntime.server.xml;
 
+import java.util.Map;
 import java.util.Properties;
 
 public class XMLTagNode extends XMLNode
@@ -48,12 +49,12 @@ public class XMLTagNode extends XMLNode
 		sb.append("<");
 		sb.append(tag);
 
-		for (Object name : attrs.keySet())
+		for (Map.Entry<Object, Object> entry : attrs.entrySet())
 		{
 			sb.append(" ");
-			sb.append(name);
+			sb.append(entry.getKey());
 			sb.append("=\"");
-			sb.append(attrs.get(name));
+			sb.append(entry.getValue());
 			sb.append("\"");
 		}
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/expression/APostOpExpAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/expression/APostOpExpAssistantInterpreter.java
@@ -12,6 +12,8 @@ import org.overture.interpreter.values.OperationValue;
 import org.overture.interpreter.values.Value;
 import org.overture.interpreter.values.ValueMap;
 
+import java.util.Map;
+
 public class APostOpExpAssistantInterpreter implements IAstAssistant
 {
 	protected static IInterpreterAssistantFactory af;
@@ -25,10 +27,10 @@ public class APostOpExpAssistantInterpreter implements IAstAssistant
 	public void populate(APostOpExp node, Context ctxt, String classname,
 			ValueMap oldvalues) throws ValueException
 	{
-		for (Value var : oldvalues.keySet())
+		for (Map.Entry<Value, Value> entry : oldvalues.entrySet())
 		{
-			String name = var.stringValue(ctxt);
-			Value val = oldvalues.get(var);
+			String name = entry.getKey().stringValue(ctxt);
+			Value val = entry.getValue();
 
 			if (!(val instanceof FunctionValue)
 					&& !(val instanceof OperationValue))

--- a/core/interpreter/src/main/java/org/overture/interpreter/eval/BinaryExpressionEvaluator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/eval/BinaryExpressionEvaluator.java
@@ -52,6 +52,8 @@ import org.overture.interpreter.values.ValueList;
 import org.overture.interpreter.values.ValueMap;
 import org.overture.interpreter.values.ValueSet;
 
+import java.util.Map;
+
 public class BinaryExpressionEvaluator extends UnaryExpressionEvaluator
 {
 
@@ -220,16 +222,16 @@ public class BinaryExpressionEvaluator extends UnaryExpressionEvaluator
 
 			ValueMap result = new ValueMap();
 
-			for (Value v : rm.keySet())
+			for (Map.Entry<Value, Value> entry : rm.entrySet())
 			{
-				Value rng = lm.get(rm.get(v));
+				Value rng = lm.get(entry.getValue());
 
 				if (rng == null)
 				{
 					VdmRuntimeError.abort(node.getLocation(), 4162, "The RHS range is not a subset of the LHS domain", ctxt);
 				}
 
-				Value old = result.put(v, rng);
+				Value old = result.put(entry.getKey(), rng);
 
 				if (old != null && !old.equals(rng))
 				{
@@ -373,15 +375,15 @@ public class BinaryExpressionEvaluator extends UnaryExpressionEvaluator
 		ValueMap result = new ValueMap();
 		result.putAll(lm);
 
-		for (Value k : rm.keySet())
+		for (Map.Entry<Value, Value> entry : rm.entrySet())
 		{
-			Value rng = rm.get(k);
-			Value old = result.put(k, rng);
+			Value rng = entry.getValue();
+			Value old = result.put(entry.getKey(), rng);
 
 			if (old != null && !old.equals(rng))
 			{
 				VdmRuntimeError.abort(node.getLocation(), 4021, "Duplicate map keys have different values: "
-						+ k, ctxt);
+						+ entry.getKey(), ctxt);
 			}
 		}
 
@@ -728,9 +730,9 @@ public class BinaryExpressionEvaluator extends UnaryExpressionEvaluator
 				ValueMap lm = new ValueMap(lv.mapValue(ctxt));
 				ValueMap rm = rv.mapValue(ctxt);
 
-				for (Value k : rm.keySet())
+				for (Map.Entry<Value, Value> entry : rm.entrySet())
 				{
-					lm.put(k, rm.get(k));
+					lm.put(entry.getKey(), entry.getValue());
 				}
 
 				return new MapValue(lm);
@@ -802,11 +804,11 @@ public class BinaryExpressionEvaluator extends UnaryExpressionEvaluator
 
 		ValueMap modified = new ValueMap(map);
 
-		for (Value k : map.keySet())
+		for (Map.Entry<Value, Value> entry : map.entrySet())
 		{
-			if (set.contains(map.get(k)))
+			if (set.contains(entry.getValue()))
 			{
-				modified.remove(k);
+				modified.remove(entry.getKey());
 			}
 		}
 
@@ -834,11 +836,11 @@ public class BinaryExpressionEvaluator extends UnaryExpressionEvaluator
 
 		ValueMap modified = new ValueMap(map);
 
-		for (Value k : map.keySet())
+		for (Map.Entry<Value, Value> entry : map.entrySet())
 		{
-			if (!set.contains(map.get(k)))
+			if (!set.contains(entry.getValue()))
 			{
-				modified.remove(k);
+				modified.remove(entry.getKey());
 			}
 		}
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/eval/UnaryExpressionEvaluator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/eval/UnaryExpressionEvaluator.java
@@ -2,6 +2,7 @@ package org.overture.interpreter.eval;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.expressions.AAbsoluteUnaryExp;
@@ -154,15 +155,15 @@ public class UnaryExpressionEvaluator extends LiteralEvaluator
 			{
 				ValueMap m = v.mapValue(ctxt);
 
-				for (Value k : m.keySet())
+				for (Map.Entry<Value, Value> entry : m.entrySet())
 				{
-					Value rng = m.get(k);
-					Value old = result.put(k, rng);
+					Value rng = entry.getValue();
+					Value old = result.put(entry.getKey(), rng);
 
 					if (old != null && !old.equals(rng))
 					{
 						VdmRuntimeError.abort(node.getLocation(), 4021, "Duplicate map keys have different values: "
-								+ k, ctxt);
+								+ entry.getKey(), ctxt);
 					}
 				}
 			}
@@ -334,9 +335,9 @@ public class UnaryExpressionEvaluator extends LiteralEvaluator
 
 			ValueMap result = new ValueMap();
 
-			for (Value k : map.keySet())
+			for (Map.Entry<Value, Value> entry : map.entrySet())
 			{
-				result.put(map.get(k), k);
+				result.put(entry.getValue(), entry.getKey());
 			}
 
 			return new MapValue(result);

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/Context.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/Context.java
@@ -24,6 +24,7 @@
 package org.overture.interpreter.runtime;
 
 import java.io.PrintWriter;
+import java.util.Map;
 
 import org.overture.ast.intf.lex.ILexLocation;
 import org.overture.ast.intf.lex.ILexNameToken;
@@ -326,9 +327,9 @@ public class Context extends LexNameTokenMap<Value>
 	{
 		StringBuilder sb = new StringBuilder();
 
-		for (ILexNameToken name : what.keySet())
+		for (Entry<ILexNameToken, Value> entry : what.entrySet())
 		{
-			sb.append(indent + name + " = " + what.get(name).toShortString(100)
+			sb.append(indent + entry.getKey() + " = " + entry.getValue().toShortString(100)
 					+ "\n");
 		}
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/BasicRuntimeValidator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/BasicRuntimeValidator.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.overture.ast.definitions.ASystemClassDefinition;
 import org.overture.ast.intf.lex.ILexNameToken;
@@ -121,11 +122,11 @@ public class BasicRuntimeValidator implements IRuntimeValidatior
 			rest.add(strings[i]);
 		}
 
-		for (ILexNameToken name : ctxt.keySet())
+		for (Map.Entry<ILexNameToken, Value> entry : ctxt.entrySet())
 		{
-			if (name.getName().equals(rest.get(0)))
+			if (entry.getKey().getName().equals(rest.get(0)))
 			{
-				Value v = ctxt.get(name);
+				Value v = entry.getValue();
 				if (rest.size() > 1)
 				{
 					return digInVariable(v, rest.subList(1, rest.size()), ctxt);
@@ -148,11 +149,11 @@ public class BasicRuntimeValidator implements IRuntimeValidatior
 			ObjectValue ov = value.objectValue(ctxt);
 			NameValuePairMap nvpm = ov.members;
 
-			for (ILexNameToken name : nvpm.keySet())
+			for (Map.Entry<ILexNameToken, Value> entry : nvpm.entrySet())
 			{
-				if (name.getName().equals(rest.get(0)))
+				if (entry.getKey().getName().equals(rest.get(0)))
 				{
-					Value v = nvpm.get(name);
+					Value v = entry.getValue();
 
 					if (rest.size() > 1)
 					{

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/TraceVariableList.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/TraceVariableList.java
@@ -24,6 +24,7 @@
 package org.overture.interpreter.traces;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Vector;
 
 import org.overture.ast.definitions.PDefinition;
@@ -48,10 +49,10 @@ public class TraceVariableList extends Vector<TraceVariable>
 	{
 		Environment local = new FlatEnvironment(ctxt.assistantFactory, localDefs);
 
-		for (ILexNameToken key : ctxt.keySet())
+		for (Map.Entry<ILexNameToken, Value> entry : ctxt.entrySet())
 		{
-			Value value = ctxt.get(key);
-			PDefinition d = local.findName(key, NameScope.NAMES);
+			Value value = entry.getValue();
+			PDefinition d = local.findName(entry.getKey(), NameScope.NAMES);
 			boolean clone = false;
 
 			if (value.isType(ObjectValue.class))
@@ -65,7 +66,7 @@ public class TraceVariableList extends Vector<TraceVariable>
 						&& obj.objectReference > self.objectReference;
 			}
 
-			add(new TraceVariable(key.getLocation(), key, value, d.getType(), clone));
+			add(new TraceVariable(entry.getKey().getLocation(), entry.getKey(), value, d.getType(), clone));
 		}
 	}
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/MapValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/MapValue.java
@@ -23,6 +23,7 @@
 
 package org.overture.interpreter.values;
 
+import java.util.Map;
 import java.util.Set;
 
 import org.overture.ast.analysis.AnalysisException;
@@ -58,10 +59,10 @@ public class MapValue extends Value
 	{
 		ValueMap nm = new ValueMap();
 
-		for (Value k : values.keySet())
+		for (Map.Entry<Value, Value> entry : values.entrySet())
 		{
-			Value v = values.get(k).getUpdatable(listeners);
-			nm.put(k, v);
+			Value v = entry.getValue().getUpdatable(listeners);
+			nm.put(entry.getKey(), v);
 		}
 
 		return UpdatableValue.factory(new MapValue(nm), listeners);
@@ -72,10 +73,10 @@ public class MapValue extends Value
 	{
 		ValueMap nm = new ValueMap();
 
-		for (Value k : values.keySet())
+		for (Map.Entry<Value, Value> entry : values.entrySet())
 		{
-			Value v = values.get(k).getConstant();
-			nm.put(k, v);
+			Value v = entry.getValue().getConstant();
+			nm.put(entry.getKey(), v);
 		}
 
 		return new MapValue(nm);
@@ -142,10 +143,10 @@ public class MapValue extends Value
 			SMapType mapto = ctxt.assistantFactory.createPTypeAssistant().getMap(to);
 			ValueMap nm = new ValueMap();
 
-			for (Value k : values.keySet())
+			for (Map.Entry<Value, Value> entry : values.entrySet())
 			{
-				Value v = values.get(k);
-				Value dom = k.convertValueTo(mapto.getFrom(), ctxt);
+				Value v = entry.getValue();
+				Value dom = entry.getKey().convertValueTo(mapto.getFrom(), ctxt);
 				Value rng = v.convertValueTo(mapto.getTo(), ctxt);
 
 				Value old = nm.put(dom, rng);

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ObjectValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ObjectValue.java
@@ -30,6 +30,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Vector;
@@ -236,11 +237,11 @@ public class ObjectValue extends Value
 
 		if (rv == null)
 		{
-			for (ILexNameToken var : members.keySet())
+			for (Entry<ILexNameToken, Value> entry : members.entrySet())
 			{
-				if (HackLexNameToken.isEqual(var, localname))
+				if (HackLexNameToken.isEqual(entry.getKey(), localname))
 				{
-					rv = members.get(var);
+					rv = entry.getValue();
 					break;
 				}
 			}
@@ -272,11 +273,11 @@ public class ObjectValue extends Value
 		// rather than using the map's hash, because the hash includes the
 		// overloaded type qualifiers...
 
-		for (ILexNameToken var : members.keySet())
+		for (Entry<ILexNameToken, Value> entry : members.entrySet())
 		{
-			if (var.matches(field)) // Ignore type qualifiers
+			if (entry.getKey().matches(field)) // Ignore type qualifiers
 			{
-				list.add(members.get(var));
+				list.add(entry.getValue());
 			}
 		}
 
@@ -342,15 +343,15 @@ public class ObjectValue extends Value
 		sb.append(type.toString());
 		sb.append("{#" + objectReference);
 
-		for (ILexNameToken name : members.keySet())
+		for (Entry<ILexNameToken, Value> entry : members.entrySet())
 		{
-			Value ov = members.get(name);
+			Value ov = entry.getValue();
 			Value v = ov.deref();
 
 			if (!(v instanceof FunctionValue) && !(v instanceof OperationValue))
 			{
 				sb.append(", ");
-				sb.append(name.getName());
+				sb.append(entry.getKey().getName());
 
 				if (ov instanceof UpdatableValue)
 				{
@@ -450,17 +451,17 @@ public class ObjectValue extends Value
 			new ObjectValue(sobj.type, new NameValuePairMap(), new Vector<ObjectValue>(), sobj.CPU, creator));
 		}
 
-		for (ILexNameToken name : members.keySet())
+		for (Entry<ILexNameToken, Value> entry : members.entrySet())
 		{
-			Value mv = members.get(name);
+			Value mv = entry.getValue();
 
 			if (mv.deref() instanceof ObjectValue)
 			{
 				ObjectValue om = (ObjectValue) mv.deref();
-				memcopy.put(name, om.shallowCopy());
+				memcopy.put(entry.getKey(), om.shallowCopy());
 			} else
 			{
-				memcopy.put(name, (Value) mv.clone());
+				memcopy.put(entry.getKey(), (Value) mv.clone());
 			}
 		}
 

--- a/core/pog/src/main/java/org/overture/pog/contexts/AssignmentContext.java
+++ b/core/pog/src/main/java/org/overture/pog/contexts/AssignmentContext.java
@@ -11,6 +11,8 @@ import org.overture.pog.pub.IPogAssistantFactory;
 import org.overture.pog.utility.Substitution;
 import org.overture.pog.visitors.IVariableSubVisitor;
 
+import java.util.Map;
+
 public class AssignmentContext extends StatefulContext
 {
 	Substitution subLast;

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ClassTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ClassTypeFinder.java
@@ -147,11 +147,11 @@ public class ClassTypeFinder extends TypeUnwrapper<AClassType>
 						ILexNameToken synthname = f.getName().getModifiedName(classname.getName());
 						PTypeSet current = null;
 
-						for (ILexNameToken n : common.keySet())
+						for (Map.Entry<ILexNameToken, PTypeSet> entry : common.entrySet())
 						{
-							if (n.getName().equals(synthname.getName()))
+							if (entry.getKey().getName().equals(synthname.getName()))
 							{
-								current = common.get(n);
+								current = entry.getValue();
 								break;
 							}
 						}
@@ -192,28 +192,28 @@ public class ClassTypeFinder extends TypeUnwrapper<AClassType>
 			List<PDefinition> newdefs = new Vector<PDefinition>();
 			PTypeAssistantTC assistant = af.createPTypeAssistant();
 
-			for (ILexNameToken synthname : common.keySet())
+			for (Map.Entry<ILexNameToken, PTypeSet> entry : common.entrySet())
 			{
-    			PType ptype = common.get(synthname).getType(type.getLocation());
+    			PType ptype = entry.getValue().getType(type.getLocation());
     			ILexNameToken newname = null;
     			
     			if (assistant.isOperation(ptype))
     			{
     				AOperationType optype = assistant.getOperation(ptype);
-    				optype.setPure(access.get(synthname).getPure());
+    				optype.setPure(access.get(entry.getKey()).getPure());
     				ptype = optype;
-    				newname = synthname.getModifiedName(optype.getParameters());
+    				newname = entry.getKey().getModifiedName(optype.getParameters());
     			}
     			else if (assistant.isFunction(ptype))
     			{
     				AFunctionType ftype = assistant.getFunction(ptype);
-    				newname = synthname.getModifiedName(ftype.getParameters());
+    				newname = entry.getKey().getModifiedName(ftype.getParameters());
     			}
     			
-    			PDefinition def = AstFactory.newALocalDefinition(synthname.getLocation(),
-    				(newname == null ? synthname : newname), NameScope.GLOBAL, ptype);
+    			PDefinition def = AstFactory.newALocalDefinition(entry.getKey().getLocation(),
+    				(newname == null ? entry.getKey() : newname), NameScope.GLOBAL, ptype);
 
-				def.setAccess(access.get(synthname).clone());
+				def.setAccess(access.get(entry.getKey()).clone());
 				newdefs.add(def);
 			}
 

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordBasisChecker.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordBasisChecker.java
@@ -124,9 +124,9 @@ public class RecordBasisChecker extends TypeUnwrapper<Boolean>
     		
     		Map<String, PTypeSet> typesets = new HashMap<String, PTypeSet>();
     		
-    		for (String field: common.keySet())
+    		for (Map.Entry<String, Vector<PType>> entry : common.entrySet())
     		{
-    			List<PType> list = common.get(field);
+    			List<PType> list = entry.getValue();
     			
     			if (list.size() != recordCount)
     			{
@@ -137,15 +137,15 @@ public class RecordBasisChecker extends TypeUnwrapper<Boolean>
     			
     			PTypeSet set = new PTypeSet(af);
     			set.addAll(list);
-    			typesets.put(field, set);
+    			typesets.put(entry.getKey(), set);
     		}
 
 			List<AFieldField> fields = new Vector<AFieldField>();
 
-			for (String tag : typesets.keySet())
+			for (Map.Entry<String, PTypeSet> entry : typesets.entrySet())
 			{
-				LexNameToken tagname = new LexNameToken("?", tag, type.getLocation());
-				fields.add(AstFactory.newAFieldField(tagname, tag, typesets.get(tag).getType(type.getLocation()), false));
+				LexNameToken tagname = new LexNameToken("?", entry.getKey(), type.getLocation());
+				fields.add(AstFactory.newAFieldField(tagname, entry.getKey(), entry.getValue().getType(type.getLocation()), false));
 			}
 
 			type.setRecType(fields.isEmpty() ? null

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordTypeFinder.java
@@ -122,9 +122,9 @@ public class RecordTypeFinder extends TypeUnwrapper<ARecordInvariantType>
     		
     		Map<String, PTypeSet> typesets = new HashMap<String, PTypeSet>();
     		
-    		for (String field: common.keySet())
+    		for (Map.Entry<String, Vector<PType>> entry : common.entrySet())
     		{
-    			List<PType> list = common.get(field);
+    			List<PType> list = entry.getValue();
     			
     			if (list.size() != recordCount)
     			{
@@ -135,15 +135,15 @@ public class RecordTypeFinder extends TypeUnwrapper<ARecordInvariantType>
     			
     			PTypeSet set = new PTypeSet(af);
     			set.addAll(list);
-    			typesets.put(field, set);
+    			typesets.put(entry.getKey(), set);
     		}
 
 			List<AFieldField> fields = new Vector<AFieldField>();
 
-			for (String tag : typesets.keySet())
+			for (Map.Entry<String, PTypeSet> entry : typesets.entrySet())
 			{
-				LexNameToken tagname = new LexNameToken("?", tag, type.getLocation());
-				fields.add(AstFactory.newAFieldField(tagname, tag, typesets.get(tag).getType(type.getLocation()), false));
+				LexNameToken tagname = new LexNameToken("?", entry.getKey(), type.getLocation());
+				fields.add(AstFactory.newAFieldField(tagname, entry.getKey(), entry.getValue().getType(type.getLocation()), false));
 			}
 
 			type.setRecType(fields.isEmpty() ? null


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2864 - “"entrySet()" should be iterated when both the key and value are needed ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2864
Please let me know if you have any questions.
Ayman Abdelghany.
