### PR TITLE
Utility classes should not have public constructors

### DIFF
--- a/core/ast/src/main/java/org/overture/ast/factory/AstExpressionFactory.java
+++ b/core/ast/src/main/java/org/overture/ast/factory/AstExpressionFactory.java
@@ -48,7 +48,10 @@ import org.overture.ast.types.PType;
 public class AstExpressionFactory
 {
 
-	public static AMkTypeExp newAMkTypeExp(ILexNameToken typeName, PType type,
+	private AstExpressionFactory() {
+	}
+
+	public static AMkTypeExp newAMkTypeExp(ILexNameToken typeName, PType type, 
 			List<PExp> arglist)
 	{
 		AMkTypeExp mktype = new AMkTypeExp();

--- a/core/ast/src/main/java/org/overture/ast/util/ToStringUtil.java
+++ b/core/ast/src/main/java/org/overture/ast/util/ToStringUtil.java
@@ -63,6 +63,9 @@ import org.overture.ast.typechecker.NameScope;
 
 public class ToStringUtil
 {
+	private ToStringUtil() {
+	}
+
 	public static String getExplicitFunctionString(AExplicitFunctionDefinition d)
 	{
 		StringBuilder params = new StringBuilder();

--- a/core/ast/src/main/java/org/overture/ast/util/Utils.java
+++ b/core/ast/src/main/java/org/overture/ast/util/Utils.java
@@ -33,6 +33,9 @@ import org.overture.ast.intf.lex.ILexNameToken;
 
 public class Utils
 {
+	private Utils() {
+	}
+
 	public static <T> String listToString(List<T> list)
 	{
 		return listToString("", list, ", ", "");

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/MapUtil.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/MapUtil.java
@@ -26,6 +26,9 @@ import java.util.Set;
 
 public class MapUtil
 {
+	private MapUtil() {
+	}
+
 	public static VDMMap map()
 	{
 		return new VDMMap();

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/SeqUtil.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/SeqUtil.java
@@ -25,6 +25,9 @@ import java.util.Collections;
 
 public class SeqUtil
 {
+	private SeqUtil() {
+	}
+
 	public static VDMSeq seq()
 	{
 		return new VDMSeq();

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/SetUtil.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/SetUtil.java
@@ -23,6 +23,9 @@ package org.overture.codegen.runtime;
 
 public class SetUtil
 {
+	private SetUtil() {
+	}
+
 	public static VDMSet set()
 	{
 		return new VDMSet();

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/StaticOperationsCounters.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/StaticOperationsCounters.java
@@ -9,7 +9,10 @@ public class StaticOperationsCounters
 	public volatile static long[] req = new long[methodnumber]; //holds the #req history counter.
 	public volatile static long[] active = new long[methodnumber]; //holds the #active history counter.
 	public volatile static long[] waiting = new long[methodnumber]; //holds the #waiting history counter.
-	
+
+	private StaticOperationsCounters() {
+	}
+
 //	public StaticOperationsCounters()
 //	{
 //		

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/Utils.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/Utils.java
@@ -25,6 +25,9 @@ public class Utils
 {
 	public static final Object VOID_VALUE = new Object();
 
+	private Utils() {
+	}
+
 	public static boolean isVoidValue(Object value)
 	{
 		return value == VOID_VALUE;

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/VDMUtil.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/VDMUtil.java
@@ -2,6 +2,9 @@ package org.overture.codegen.runtime;
 
 public class VDMUtil
 {
+	private VDMUtil() {
+	}
+
 	public static String val2seq_of_char(Object value)
 	{
 		return Utils.toString(value);

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/TraceUtil.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/TraceUtil.java
@@ -4,6 +4,9 @@ import java.lang.reflect.Field;
 
 public class TraceUtil
 {
+	private TraceUtil() {
+	}
+
 	public static <T> T readState(Class<?> module, Class<T> stateType)
 	{
 		Field[] fields = module.getDeclaredFields();

--- a/core/codegen/ir/src/main/java/org/overture/codegen/ir/IrToStringUtil.java
+++ b/core/codegen/ir/src/main/java/org/overture/codegen/ir/IrToStringUtil.java
@@ -5,6 +5,9 @@ import org.overture.codegen.ir.statements.ABlockStmIR;
 
 public class IrToStringUtil
 {
+	private IrToStringUtil() {
+	}
+
 	public static String getSimpleBlockString(ABlockStmIR node)
 	{
 		StringBuilder sb = new StringBuilder();

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaCommandLineCompiler.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaCommandLineCompiler.java
@@ -32,6 +32,9 @@ import org.overture.codegen.tests.util.JavaToolsUtils;
 
 public class JavaCommandLineCompiler
 {
+	private JavaCommandLineCompiler() {
+	}
+
 	public static ProcessResult compile(File dir, File[] cpJars)
 	{
 		String javaHome = System.getenv(JavaToolsUtils.JAVA_HOME);

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/output/util/OutputTestUtil.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/output/util/OutputTestUtil.java
@@ -16,7 +16,10 @@ public class OutputTestUtil
 	public static final String UPDATE_PROPERTY_PREFIX = "tests.javagen.override.";
 	public static final String UPDATE_ALL_OUTPUT_TESTS_PROPERTY = UPDATE_PROPERTY_PREFIX
 			+ "all";
-	
+
+	private OutputTestUtil() {
+	}
+
 	public static void compare(String expected, String actual)
 	{
 		Assert.assertEquals("Unexpected code produced by the Java code generator", expected.trim(), actual.trim());

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/util/JavaToolsUtils.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/util/JavaToolsUtils.java
@@ -38,7 +38,10 @@ public class JavaToolsUtils
 	public static final String CP_ARG = "-classpath";
 
 	public static final String JAVA_FILE_EXTENSION = ".java";
-	
+
+	private JavaToolsUtils() {
+	}
+
 	public static Boolean isWindows()
 	{
 		String osName = System.getProperty("os.name");

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenUtil.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenUtil.java
@@ -48,6 +48,9 @@ import de.hunsicker.jalopy.Jalopy;
 
 public class JavaCodeGenUtil
 {
+	private JavaCodeGenUtil() {
+	}
+
 	public static Generated generateJavaFromExp(String exp,
 			IRSettings irSettings, JavaSettings javaSettings, Dialect dialect)
 			throws AnalysisException

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/TemplateCallableManager.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/TemplateCallableManager.java
@@ -28,6 +28,9 @@ public class TemplateCallableManager
 	private static final String JAVA_FORMAT_KEY = "JavaFormat";
 	private static final String VALUE_SEMANTICS = "ValueSemantics";
 
+	private TemplateCallableManager() {
+	}
+
 	public final static TemplateCallable[] constructTemplateCallables(
 			Object javaFormat, Object valueSemantics)
 	{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralCodeGenUtils.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralCodeGenUtils.java
@@ -82,7 +82,10 @@ import org.overture.typechecker.visitor.TypeCheckVisitor;
 public class GeneralCodeGenUtils
 {
 	private static final String LINE_SEPARATOR = System.getProperty("line.separator");
-	
+
+	private GeneralCodeGenUtils() {
+	}
+
 	public static boolean isVdmSourceFile(File f)
 	{
 		return isVdmPpSourceFile(f) || isVdmSlSourceFile(f) || isVdmRtSourceFile(f);

--- a/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralUtils.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralUtils.java
@@ -36,6 +36,9 @@ import java.util.List;
 
 public class GeneralUtils
 {
+	private GeneralUtils() {
+	}
+
 	public static boolean isEscapeSequence(char c)
 	{
 		return c == '\t' || c == '\b' || c == '\n' || c == '\r' || c == '\f'

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/common/Utils.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/common/Utils.java
@@ -23,6 +23,9 @@ package org.overture.ct.ctruntime.server.common;
 
 public class Utils
 {
+	private Utils() {
+	}
+
 	public static void pause(int secs)
 	{
 		milliPause(secs * 1000);

--- a/core/interpreter/src/main/java/VDMUtil.java
+++ b/core/interpreter/src/main/java/VDMUtil.java
@@ -29,6 +29,9 @@ import org.overture.parser.syntax.ExpressionReader;
 
 public class VDMUtil
 {
+	private VDMUtil() {
+	}
+
 	public static Value set2seq(Value arg) throws ValueException
 	{
 		ValueSet set = arg.setValue(null);

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/BreakpointManager.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/BreakpointManager.java
@@ -19,7 +19,10 @@ public class BreakpointManager
 
 	static final Map<PExp, Breakpoint> expressionMap = new HashMap<PExp, Breakpoint>();
 	static final Map<PStm, Breakpoint> statementMap = new HashMap<PStm, Breakpoint>();
-	
+
+	private BreakpointManager() {
+	}
+
 	public static Breakpoint getBreakpoint(INode node) throws AnalysisException
 	{
 		if(node instanceof PExp)

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPExecProcesser.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPExecProcesser.java
@@ -24,6 +24,9 @@ import org.overture.parser.syntax.ParserException;
 
 public class DBGPExecProcesser
 {
+	private DBGPExecProcesser() {
+	}
+
 	public static class DBGPExecResult
 	{
 		public final String result;

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/RuntimeValidator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/RuntimeValidator.java
@@ -41,6 +41,9 @@ public class RuntimeValidator
 	public static IRuntimeValidatior validator;
 	private static PrintWriter logfile = null;
 
+	private RuntimeValidator() {
+	}
+
 	public static void init(ClassInterpreter classInterpreter)
 	{
 		if (Settings.timingInvChecks)

--- a/core/interpreter/src/main/java/org/overture/interpreter/solver/SolverFactory.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/solver/SolverFactory.java
@@ -7,6 +7,9 @@ import org.overture.typechecker.assistant.TypeCheckerAssistantFactory;
 public class SolverFactory
 {
 
+	private SolverFactory() {
+	}
+
 	public static IConstraintSolver getSolver(Dialect dialect)
 	{
 		try

--- a/core/interpreter/src/main/java/org/overture/interpreter/util/InterpreterUtil.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/util/InterpreterUtil.java
@@ -16,6 +16,9 @@ import org.overture.typechecker.util.TypeCheckerUtil.TypeCheckResult;
 
 public class InterpreterUtil
 {
+	private InterpreterUtil() {
+	}
+
 	public static Interpreter getInterpreter(ModuleListInterpreter modules)
 			throws Exception
 	{

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/utils/ExecutionToResultTranslator.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/utils/ExecutionToResultTranslator.java
@@ -17,6 +17,9 @@ import org.overture.test.framework.results.Result;
 
 public class ExecutionToResultTranslator
 {
+	private ExecutionToResultTranslator() {
+	}
+
 	public static Result<Value> wrapValue(Exception e)
 	{
 		Result<String> result = wrap(e);

--- a/core/parser/src/main/java/org/overture/parser/util/ParserUtil.java
+++ b/core/parser/src/main/java/org/overture/parser/util/ParserUtil.java
@@ -40,6 +40,9 @@ import org.overture.parser.syntax.ParserException;
 
 public class ParserUtil
 {
+	private ParserUtil() {
+	}
+
 	public static class ParserResult<T>
 	{
 		public static interface IResultCombiner<T>

--- a/core/pog/src/main/java/org/overture/pog/pub/ProofObligationGenerator.java
+++ b/core/pog/src/main/java/org/overture/pog/pub/ProofObligationGenerator.java
@@ -10,6 +10,9 @@ import org.overture.pog.visitors.PogVisitor;
 
 public class ProofObligationGenerator
 {
+	private ProofObligationGenerator() {
+	}
+
 	public static IProofObligationList generateProofObligations(INode root)
 			throws AnalysisException
 	{

--- a/core/testframework/src/main/java/org/overture/test/util/FileUtils.java
+++ b/core/testframework/src/main/java/org/overture/test/util/FileUtils.java
@@ -35,6 +35,9 @@ import java.util.List;
 public class FileUtils
 {
 
+	private FileUtils() {
+	}
+
 	public static List<String> readTextFromJar(String s) throws Exception
 	{
 		InputStream is = null;

--- a/core/testing/framework/src/main/java/org/overture/core/tests/PathsProvider.java
+++ b/core/testing/framework/src/main/java/org/overture/core/tests/PathsProvider.java
@@ -50,6 +50,9 @@ public class PathsProvider
 
 	private final static String EXTERNAL_VDM_EXTENSION_REGEX = "(.*)\\.(vdm|vpp)";
 
+	private PathsProvider() {
+	}
+
 	/**
 	 * Processes (recursively) a folder of source inputs. The source input files must have one of the
 	 * three VDM extensions (,vdmsl, .vdmpp, .vdmrt). <br>

--- a/core/typechecker/src/main/java/org/overture/typechecker/util/TypeCheckerUtil.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/util/TypeCheckerUtil.java
@@ -52,6 +52,9 @@ import org.overture.typechecker.visitor.TypeCheckVisitor;
 
 public class TypeCheckerUtil
 {
+	private TypeCheckerUtil() {
+	}
+
 	public static class TypeCheckResult<T>
 	{
 		public final ParserResult<T> parserResult;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - “Utility classes should not have public constructors ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.
