### PR TITLE
Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/core/ast/src/main/java/org/overture/ast/assistant/type/AUnionTypeAssistant.java
+++ b/core/ast/src/main/java/org/overture/ast/assistant/type/AUnionTypeAssistant.java
@@ -23,6 +23,7 @@ package org.overture.ast.assistant.type;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.assistant.IAstAssistant;
 import org.overture.ast.assistant.IAstAssistantFactory;
@@ -67,7 +68,7 @@ public class AUnionTypeAssistant implements IAstAssistant
 			}
 		}
 
-		Vector<PType> v = new Vector<PType>(exptypes);
+		ArrayList<PType> v = new ArrayList<PType>(exptypes);
 		type.setTypes(v);
 		type.setExpanded(true);
 		List<PDefinition> definitions = type.getDefinitions();

--- a/core/ast/src/main/java/org/overture/ast/factory/AstFactory.java
+++ b/core/ast/src/main/java/org/overture/ast/factory/AstFactory.java
@@ -606,7 +606,7 @@ public class AstFactory
 		AFunctionType type = AstFactory.newAFunctionType(result.getLocation(), false, ptypes, resultPattern.getType());
 		type.setInstantiated(typeParams == null || typeParams.isEmpty() ? null : false);
 
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 		defs.add(result);
 		type.setDefinitions(defs);
 		result.setType(type);
@@ -630,7 +630,7 @@ public class AstFactory
 
 	private static List<PType> getTypeList(APatternListTypePair node)
 	{
-		List<PType> list = new Vector<PType>();
+		List<PType> list = new ArrayList<PType>();
 
 		for (int i = 0; i < node.getPatterns().size(); i++)
 		{
@@ -658,7 +658,7 @@ public class AstFactory
 		result.setType(type);
 		result.setExpression(readExpression);
 
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		for (ILexNameToken var : af.createPPatternAssistant().getVariableNames(p))
 		{
@@ -697,7 +697,7 @@ public class AstFactory
 		result.setInitPattern(initPattern);
 		result.setInitExpression(initExpression);
 
-		List<PDefinition> stateDefs = new Vector<PDefinition>();
+		List<PDefinition> stateDefs = new ArrayList<PDefinition>();
 
 		for (AFieldField f : fields)
 		{
@@ -775,7 +775,7 @@ public class AstFactory
 		result.setErrors(spec.getErrors());
 		result.setIsConstructor(false);
 
-		List<PType> ptypes = new Vector<PType>();
+		List<PType> ptypes = new ArrayList<PType>();
 
 		for (APatternListTypePair ptp : parameterPatterns)
 		{
@@ -935,7 +935,7 @@ public class AstFactory
 		// used to be a static method on LexNameToken - removed when we went to
 		// interface
 		result.setOperationName(new LexNameToken(statement.getLocation().getModule(), "thread", statement.getLocation()));
-		result.getOperationName().setTypeQualifier(new Vector<PType>());
+		result.getOperationName().setTypeQualifier(new ArrayList<PType>());
 		result.setAccess(af.createPAccessSpecifierAssistant().getProtected());
 
 		return result;
@@ -1018,7 +1018,7 @@ public class AstFactory
 		// Definition initialization
 		initDefinition(result, Pass.DEFS, location, new LexNameToken(location.getModule(), Utils.listToString(pathname, "_"), location), NameScope.GLOBAL);
 
-		List<ClonableString> namesClonable = new Vector<ClonableString>();
+		List<ClonableString> namesClonable = new ArrayList<ClonableString>();
 		for (String string : pathname)
 		{
 			namesClonable.add(new ClonableString(string));
@@ -1433,7 +1433,7 @@ public class AstFactory
 		AApplyExp result = new AApplyExp();
 		result.setLocation(root.getLocation());
 		result.setRoot(root);
-		result.setArgs(new Vector<PExp>());
+		result.setArgs(new ArrayList<PExp>());
 		return result;
 	}
 
@@ -1778,7 +1778,7 @@ public class AstFactory
 		ASetEnumSetExp result = new ASetEnumSetExp();
 		initExpression(result, start);
 
-		result.setMembers(new Vector<PExp>());
+		result.setMembers(new ArrayList<PExp>());
 		return result;
 	}
 
@@ -1787,7 +1787,7 @@ public class AstFactory
 		AMapEnumMapExp result = new AMapEnumMapExp();
 		initExpression(result, start);
 
-		result.setMembers(new Vector<AMapletExp>());
+		result.setMembers(new ArrayList<AMapletExp>());
 		return result;
 	}
 
@@ -1854,7 +1854,7 @@ public class AstFactory
 		ASeqEnumSeqExp result = new ASeqEnumSeqExp();
 		initExpression(result, start);
 
-		result.setMembers(new Vector<PExp>());
+		result.setMembers(new ArrayList<PExp>());
 
 		return result;
 	}
@@ -2136,15 +2136,15 @@ public class AstFactory
 		result.setTypeChecked(false);
 		result.setIsDLModule(false); // TODO: this does not exist in VDMj
 
-		List<ClonableFile> files = new Vector<ClonableFile>();
+		List<ClonableFile> files = new ArrayList<ClonableFile>();
 		if (file != null)
 		{
 			files.add(new ClonableFile(file));
 		}
 		result.setFiles(files);
 
-		result.setExportdefs(new Vector<PDefinition>()); // Export nothing
-		result.setImportdefs(new Vector<PDefinition>()); // and import nothing
+		result.setExportdefs(new ArrayList<PDefinition>()); // Export nothing
+		result.setImportdefs(new ArrayList<PDefinition>()); // and import nothing
 
 		result.setIsFlat(true);
 
@@ -2178,16 +2178,16 @@ public class AstFactory
 		result.setExports(exports);
 		result.setDefs(defs);
 
-		List<ClonableFile> files = new Vector<ClonableFile>();
+		List<ClonableFile> files = new ArrayList<ClonableFile>();
 		files.add(new ClonableFile(name.location.getFile()));
 		result.setFiles(files);
 		result.setIsFlat(false);
 		result.setTypeChecked(false);
 		result.setIsDLModule(false); // TODO: this does not exist in VDMj
 
-		result.setExportdefs(new Vector<PDefinition>()); // By default, export
+		result.setExportdefs(new ArrayList<PDefinition>()); // By default, export
 															// nothing
-		result.setImportdefs(new Vector<PDefinition>()); // and import nothing
+		result.setImportdefs(new ArrayList<PDefinition>()); // and import nothing
 
 		// Reset parent set by member graph field
 		result.parent(null);
@@ -2546,7 +2546,7 @@ public class AstFactory
 		ANonDeterministicSimpleBlockStm result = new ANonDeterministicSimpleBlockStm();
 		initStatement(result, token);
 
-		result.setStatements(new Vector<PStm>());
+		result.setStatements(new ArrayList<PStm>());
 
 		return result;
 	}
@@ -2917,7 +2917,7 @@ public class AstFactory
 		initType(result, location);
 		initUnionType(result);
 
-		List<PType> list = new Vector<PType>();
+		List<PType> list = new ArrayList<PType>();
 		list.add(a);
 		list.add(b);
 		result.setTypes(list);
@@ -3056,7 +3056,7 @@ public class AstFactory
 	{
 		AOperationType result = new AOperationType();
 		initType(result, location);
-		result.setParameters(new Vector<PType>());
+		result.setParameters(new ArrayList<PType>());
 		result.setResult(AstFactory.newAVoidType(location));
 		result.setPure(false);
 
@@ -3114,7 +3114,7 @@ public class AstFactory
 
 	public static AClassClassDefinition newAClassClassDefinition()
 	{
-		AClassClassDefinition result = AstFactory.newAClassClassDefinition(new LexNameToken("CLASS", "DEFAULT", new LexLocation()), new LexNameList(), new Vector<PDefinition>());
+		AClassClassDefinition result = AstFactory.newAClassClassDefinition(new LexNameToken("CLASS", "DEFAULT", new LexLocation()), new LexNameList(), new ArrayList<PDefinition>());
 		// TODO: missing types in AClassClassDefinition
 		// privateStaticValues = new NameValuePairMap();
 		// publicStaticValues = new NameValuePairMap();
@@ -3482,7 +3482,7 @@ public class AstFactory
 
 	public static AModuleModules newAModuleModules()
 	{
-		return newAModuleModules(null, new Vector<PDefinition>());
+		return newAModuleModules(null, new ArrayList<PDefinition>());
 	}
 
 	public static ANarrowExp newANarrowExpression(ILexLocation location,

--- a/core/ast/src/main/java/org/overture/ast/lex/LexLocation.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexLocation.java
@@ -29,6 +29,7 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
@@ -453,7 +454,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 	{
 		//FIXME skip lex location in other files
 		// idea: if !lextLocation.getFile().equals(file) then continue; 
-		List<Integer> hits = new Vector<Integer>();
+		List<Integer> hits = new ArrayList<Integer>();
 
 		synchronized (allLocations)
 		{
@@ -471,7 +472,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 	public static List<Integer> getMissList(File file)
 	{
-		List<Integer> misses = new Vector<Integer>();
+		List<Integer> misses = new ArrayList<Integer>();
 
 		synchronized (allLocations)
 		{
@@ -489,7 +490,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 	public static List<Integer> getSourceList(File file)
 	{
-		List<Integer> lines = new Vector<Integer>();
+		List<Integer> lines = new ArrayList<Integer>();
 		int last = 0;
 
 		synchronized (allLocations)
@@ -521,7 +522,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 					if (list == null)
 					{
-						list = new Vector<LexLocation>();
+						list = new ArrayList<LexLocation>();
 						map.put(l.startLine, list);
 					}
 
@@ -573,7 +574,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 					if (list == null)
 					{
-						list = new Vector<LexLocation>();
+						list = new ArrayList<LexLocation>();
 						map.put(l.startLine, list);
 					}
 
@@ -587,7 +588,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 	public static List<LexLocation> getSourceLocations(File file)
 	{
-		List<LexLocation> locations = new Vector<LexLocation>();
+		List<LexLocation> locations = new ArrayList<LexLocation>();
 
 		synchronized (allLocations)
 		{
@@ -650,7 +651,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 	 */
 	public static List<LexLocation> removeDuplicates(List<LexLocation> locations)
 	{
-		List<LexLocation> tmp = new Vector<LexLocation>();
+		List<LexLocation> tmp = new ArrayList<LexLocation>();
 		c: for (LexLocation l1 : locations)
 		{
 			if (l1.hits == 0)

--- a/core/ast/src/main/java/org/overture/ast/lex/LexLocationUtils.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexLocationUtils.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Hashtable;
 import java.util.List;
@@ -193,7 +194,7 @@ public class LexLocationUtils implements Serializable
 
 	public static List<Integer> getHitList(File file)
 	{
-		List<Integer> hits = new Vector<Integer>();
+		List<Integer> hits = new ArrayList<Integer>();
 
 		synchronized (allLocations)
 		{
@@ -211,7 +212,7 @@ public class LexLocationUtils implements Serializable
 
 	public static List<Integer> getMissList(File file)
 	{
-		List<Integer> misses = new Vector<Integer>();
+		List<Integer> misses = new ArrayList<Integer>();
 
 		synchronized (allLocations)
 		{
@@ -229,7 +230,7 @@ public class LexLocationUtils implements Serializable
 
 	public static List<Integer> getSourceList(File file)
 	{
-		List<Integer> lines = new Vector<Integer>();
+		List<Integer> lines = new ArrayList<Integer>();
 		int last = 0;
 
 		synchronized (allLocations)
@@ -263,7 +264,7 @@ public class LexLocationUtils implements Serializable
 
 					if (list == null)
 					{
-						list = new Vector<ILexLocation>();
+						list = new ArrayList<ILexLocation>();
 						map.put(l.getStartLine(), list);
 					}
 
@@ -316,7 +317,7 @@ public class LexLocationUtils implements Serializable
 
 					if (list == null)
 					{
-						list = new Vector<ILexLocation>();
+						list = new ArrayList<ILexLocation>();
 						map.put(l.getStartLine(), list);
 					}
 
@@ -330,7 +331,7 @@ public class LexLocationUtils implements Serializable
 
 	public static List<ILexLocation> getSourceLocations(File file)
 	{
-		List<ILexLocation> locations = new Vector<ILexLocation>();
+		List<ILexLocation> locations = new ArrayList<ILexLocation>();
 
 		synchronized (allLocations)
 		{

--- a/core/ast/src/main/java/org/overture/ast/lex/LexNameToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexNameToken.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.intf.IAnalysis;
@@ -191,13 +192,13 @@ public class LexNameToken extends LexToken implements ILexNameToken,
 		if (module.equals("CLASS"))
 		{
 			LexNameToken thread = new LexNameToken(name, "thread", location);
-			thread.setTypeQualifier(new Vector<PType>());
+			thread.setTypeQualifier(new ArrayList<PType>());
 			return thread;
 		}
 		else
 		{
 			LexNameToken thread = new LexNameToken(module, "thread", location);
-			thread.setTypeQualifier(new Vector<PType>());
+			thread.setTypeQualifier(new ArrayList<PType>());
 			return thread;
 		}
 	}
@@ -205,7 +206,7 @@ public class LexNameToken extends LexToken implements ILexNameToken,
 	public LexNameToken getThreadName(ILexLocation loc)
 	{
 		LexNameToken thread = new LexNameToken(loc.getModule(), "thread", loc);
-		thread.setTypeQualifier(new Vector<PType>());
+		thread.setTypeQualifier(new ArrayList<PType>());
 		return thread;
 	}
 

--- a/core/ast/src/main/java/org/overture/ast/util/ToStringUtil.java
+++ b/core/ast/src/main/java/org/overture/ast/util/ToStringUtil.java
@@ -21,6 +21,7 @@
  */
 package org.overture.ast.util;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
@@ -112,7 +113,7 @@ public class ToStringUtil
 
 	private static List<String> getString(List<APatternListTypePair> node)
 	{
-		List<String> list = new Vector<String>();
+		List<String> list = new ArrayList<String>();
 		for (APatternListTypePair pl : node)
 		{
 			list.add("(" + getStringPattern(pl.getPatterns()) + ":"

--- a/core/ast/src/main/java/org/overture/ast/util/modules/CombinedDefaultModule.java
+++ b/core/ast/src/main/java/org/overture/ast/util/modules/CombinedDefaultModule.java
@@ -21,6 +21,7 @@
  */
 package org.overture.ast.util.modules;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
@@ -51,7 +52,7 @@ public class CombinedDefaultModule extends AModuleModules
 	@SuppressWarnings("deprecation")
 	public CombinedDefaultModule(Set<AModuleModules> modules)
 	{
-		super(null, null, null, new Vector<PDefinition>(), new Vector<ClonableFile>(), true, false);
+		super(null, null, null, new ArrayList<PDefinition>(), new ArrayList<ClonableFile>(), true, false);
 		this.modules.addAll(modules);
 
 		if (getDefs().isEmpty())

--- a/core/ast/src/main/java/org/overture/ast/util/modules/ModuleList.java
+++ b/core/ast/src/main/java/org/overture/ast/util/modules/ModuleList.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.ANamedTraceDefinition;
 import org.overture.ast.definitions.PDefinition;
@@ -99,7 +100,7 @@ public class ModuleList extends Vector<AModuleModules>
 				// In VDM-10, we implicitly import all from the other
 				// modules included with the flat specifications (if any).
 
-				List<AFromModuleImports> imports = new Vector<AFromModuleImports>();
+				List<AFromModuleImports> imports = new ArrayList<AFromModuleImports>();
 
 				for (AModuleModules m : this)
 				{
@@ -165,9 +166,9 @@ public class ModuleList extends Vector<AModuleModules>
 	// This function is copied from the module reader
 	private AFromModuleImports importAll(ILexIdentifierToken from)
 	{
-		List<List<PImport>> types = new Vector<List<PImport>>();
+		List<List<PImport>> types = new ArrayList<List<PImport>>();
 		ILexNameToken all = new LexNameToken(from.getName(), "all", from.getLocation());
-		List<PImport> impAll = new Vector<PImport>();
+		List<PImport> impAll = new ArrayList<PImport>();
 		AAllImport iport = AstFactory.newAAllImport(all);
 		iport.setLocation(all.getLocation());
 		iport.setName(all);

--- a/core/codegen/codegen-maven-plugin/src/main/java/org/overture/codegen/mojocg/Vdm2JavaMojo.java
+++ b/core/codegen/codegen-maven-plugin/src/main/java/org/overture/codegen/mojocg/Vdm2JavaMojo.java
@@ -97,7 +97,7 @@ public class Vdm2JavaMojo extends Vdm2JavaBaseMojo
 
 		outputDirectory.mkdirs();
 
-		List<File> tmp = new Vector<File>();
+		List<File> tmp = new ArrayList<File>();
 		tmp.addAll(files);
 		
 		if(release.equals(VDM_10))

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/ConcurrentTraceNode.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/ConcurrentTraceNode.java
@@ -53,7 +53,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 		}
 		Pair<Integer, Integer> v = indics.get(index);
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new ArrayList<TestSequence>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)
@@ -130,7 +130,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 
 		int size = 0;
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new ArrayList<TestSequence>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/SequenceTraceNode.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/SequenceTraceNode.java
@@ -55,7 +55,7 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 
 		CallSequence seq = getVars();
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new ArrayList<TestSequence>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)
@@ -93,7 +93,7 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 
 		indics = new HashMap<Integer, Integer[]>();
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new ArrayList<TestSequence>();
 		int count = nodes.size();
 		int[] sizes = new int[count];
 		int n = 0;

--- a/core/codegen/isagen/src/main/java/org/overturetool/cgisa/transformations/Dependencies.java
+++ b/core/codegen/isagen/src/main/java/org/overturetool/cgisa/transformations/Dependencies.java
@@ -83,7 +83,7 @@ public class Dependencies
 					r.put(decl, dependencies);
 				} else
 				{
-					r.put(decl, new Vector<SDeclIR>());
+					r.put(decl, new ArrayList<SDeclIR>());
 				}
 			} catch (AnalysisException e)
 			{
@@ -110,7 +110,7 @@ public class Dependencies
 			}
 		});
 
-		List<SDeclIR> deps = new Vector<SDeclIR>();
+		List<SDeclIR> deps = new ArrayList<SDeclIR>();
 		for (SVarExpIR v : vars)
 		{
 			for (SDeclIR d : decls)

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/CheckerTestBase.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/CheckerTestBase.java
@@ -39,7 +39,7 @@ public abstract class CheckerTestBase extends JavaCodeGenTestCase
 	protected static Collection<Object[]> collectTests(File root,
 			TestHandler handler)
 	{
-		Collection<Object[]> tests = new Vector<Object[]>();
+		Collection<Object[]> tests = new ArrayList<Object[]>();
 
 		List<File> vdmSources = TestUtils.getTestInputFiles(root);
 
@@ -132,7 +132,7 @@ public abstract class CheckerTestBase extends JavaCodeGenTestCase
 			if (Properties.recordTestResults)
 			{
 				Object vdmResult = evalVdm(file, executableTestHandler);
-				return new Result<Object>(vdmResult, new Vector<IMessage>(), new Vector<IMessage>());
+				return new Result<Object>(vdmResult, new ArrayList<IMessage>(), new ArrayList<IMessage>());
 			}
 
 			// Note that the classes returned in javaResult may be loaded by another class loader. This is the case for
@@ -145,14 +145,14 @@ public abstract class CheckerTestBase extends JavaCodeGenTestCase
 				Assert.fail("No Java result could be produced");
 			}
 
-			return new Result<Object>(javaResult, new Vector<IMessage>(), new Vector<IMessage>());
+			return new Result<Object>(javaResult, new ArrayList<IMessage>(), new ArrayList<IMessage>());
 
 		}
 
 		Assert.fail("Trying to produce result using an unsupported test handler: "
 				+ testHandler);
 
-		return new Result<Object>(null, new Vector<IMessage>(), new Vector<IMessage>());
+		return new Result<Object>(null, new ArrayList<IMessage>(), new ArrayList<IMessage>());
 	}
 
 	public  File[] consCpFiles()

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaCommandLineCompiler.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaCommandLineCompiler.java
@@ -157,7 +157,7 @@ public class JavaCommandLineCompiler
 
 	private static List<File> getJavaSourceFiles(File file)
 	{
-		List<File> files = new Vector<File>();
+		List<File> files = new ArrayList<File>();
 
 		if (file.isFile())
 		{

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaExecution.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaExecution.java
@@ -57,7 +57,7 @@ public class JavaExecution
 			String javaArg = JavaToolsUtils.isWindows() ? java.getAbsolutePath()
 					: "java";
 
-			List<String> commands = new Vector<String>();
+			List<String> commands = new ArrayList<String>();
 			commands.add(javaArg);
 			commands.addAll(Arrays.asList(preArgs));
 			commands.add("-cp");

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/util/TestUtils.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/util/TestUtils.java
@@ -34,7 +34,7 @@ public class TestUtils
 {
 	public static List<File> getTestInputFiles(File file)
 	{
-		List<File> files = new Vector<File>();
+		List<File> files = new ArrayList<File>();
 		for (File f : file.listFiles())
 		{
 			Collections.sort(files, new FileComparator());

--- a/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/VarShadowingRenameCollector.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/VarShadowingRenameCollector.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.DepthFirstAnalysisAdaptor;
@@ -672,7 +673,7 @@ public class VarShadowingRenameCollector extends DepthFirstAnalysisAdaptor
 	
 	private List<PDefinition> getMultipleBindDefs(List<PMultipleBind> bindings)
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		for (PMultipleBind mb : bindings)
 		{

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceInterpreter.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceInterpreter.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.ANamedTraceDefinition;
@@ -217,7 +218,7 @@ public class TraceInterpreter
 	private List<ANamedTraceDefinition> getAllTraceDefinitions(
 			List<PDefinition> definitions, String traceName)
 	{
-		List<ANamedTraceDefinition> traceDefs = new Vector<ANamedTraceDefinition>();
+		List<ANamedTraceDefinition> traceDefs = new ArrayList<ANamedTraceDefinition>();
 
 		for (Object definition : definitions)
 		{
@@ -318,7 +319,7 @@ public class TraceInterpreter
 				}
 			} catch (Exception e)
 			{
-				result = new Vector<Object>();
+				result = new ArrayList<Object>();
 				result.add(e);
 				verdict = Verdict.FAILED;
 				result.add(verdict);
@@ -435,14 +436,14 @@ public class TraceInterpreter
 			env = new FlatEnvironment(interpreter.getAssistantFactory(), classdef.apply(interpreter.getAssistantFactory().getSelfDefinitionFinder()), outer);
 		} else
 		{
-			List<PDefinition> defs = new Vector<>();
+			List<PDefinition> defs = new ArrayList<>();
 			
 			if(classdef instanceof AModuleModules)
 			{
 				defs.addAll(((AModuleModules) classdef).getDefs());
 			}
 			
-			env = new FlatEnvironment(interpreter.getAssistantFactory(), new Vector<PDefinition>(), outer);
+			env = new FlatEnvironment(interpreter.getAssistantFactory(), new ArrayList<PDefinition>(), outer);
 		}
 
 		for (int i = 0; i < test.size(); i++)
@@ -479,7 +480,7 @@ public class TraceInterpreter
 			result = interpreter.runOneTrace(mtd, test, false);
 		} catch (Exception e)
 		{
-			result = new Vector<Object>();
+			result = new ArrayList<Object>();
 			result.add(e.getMessage());
 			result.add(e);
 			result.add(Verdict.ERROR);

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceRunnerMain.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceRunnerMain.java
@@ -37,6 +37,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.lex.Dialect;
 import org.overture.config.Release;
@@ -121,7 +122,7 @@ public class TraceRunnerMain implements IProgressMonitor
 		String ideKey = null;
 		Settings.dialect = null;
 		String moduleName = null;
-		List<File> files = new Vector<File>();
+		List<File> files = new ArrayList<File>();
 		List<String> largs = Arrays.asList(args);
 		VDMJ controller = null;
 		boolean warnings = true;

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/xml/XMLParser.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/xml/XMLParser.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 import java.util.Vector;
+import java.util.ArrayList;
 
 public class XMLParser
 {
@@ -299,7 +300,7 @@ public class XMLParser
 		checkFor(Token.TAG);
 
 		Properties attr = null;
-		List<XMLNode> children = new Vector<XMLNode>();
+		List<XMLNode> children = new ArrayList<XMLNode>();
 
 		if (token == Token.TAG)
 		{

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/CtHelper.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/CtHelper.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.lex.Dialect;
 import org.overture.config.Release;
@@ -97,7 +98,7 @@ public class CtHelper
 						+ data.reduction.getReductionType().toString() + ","
 						+ data.reduction.getSeed() + "}" };
 		
-		List<String> argArray = new Vector<String>(Arrays.asList(args));
+		List<String> argArray = new ArrayList<String>(Arrays.asList(args));
 		
 		
 		for (Iterator<File> itr = data.specFiles.iterator(); itr.hasNext();)

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/TraceResult.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/TraceResult.java
@@ -23,11 +23,12 @@ package org.overture.ct.ctruntime.utils;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 public class TraceResult
 {
 	public String traceName;
-	public List<TraceTest> tests = new Vector<TraceTest>();
+	public List<TraceTest> tests = new ArrayList<TraceTest>();
 
 	@Override
 	public String toString()

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/TraceResultReader.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/TraceResultReader.java
@@ -26,6 +26,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -48,7 +49,7 @@ public class TraceResultReader
 	public List<TraceResult> read(File file) throws SAXException, IOException,
 			ParserConfigurationException, XPathExpressionException
 	{
-		List<TraceResult> results = new Vector<TraceResult>();
+		List<TraceResult> results = new ArrayList<TraceResult>();
 
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		factory.setNamespaceAware(true);

--- a/core/combinatorialtesting/ctruntime/src/test/java/org/overture/ct/ctruntime/tests/CtRandomReductionSlTestCase.java
+++ b/core/combinatorialtesting/ctruntime/src/test/java/org/overture/ct/ctruntime/tests/CtRandomReductionSlTestCase.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.Assert;
@@ -63,7 +64,7 @@ public class CtRandomReductionSlTestCase extends CtTestCaseBase
     @Parameters(name = "{0}")
 	public static Collection<Object[]> getData()
 	{
-	    List<ReductionTestData> testReduction = new Vector<>();
+	    List<ReductionTestData> testReduction = new ArrayList<>();
 		testReduction.add(new ReductionTestData("OpRepeatedTenTimes", new TraceReductionInfo(0.15F, TraceReductionType.RANDOM, SEED),2));
 		testReduction.add(new ReductionTestData("ThreeAlternativeOpCalls", new TraceReductionInfo(0.1F, TraceReductionType.RANDOM, SEED),1));
         testReduction.add(new ReductionTestData("ThreeConcurrentOpCalls", new TraceReductionInfo(0.30F, TraceReductionType.RANDOM, SEED),2));
@@ -74,7 +75,7 @@ public class CtRandomReductionSlTestCase extends CtTestCaseBase
 		testReduction.add(new ReductionTestData("PaperCaseStudy", new TraceReductionInfo(0.01F, TraceReductionType.SHAPES_VARNAMES, SEED),3));
 		testReduction.add(new ReductionTestData("PaperCaseStudy", new TraceReductionInfo(0.01F, TraceReductionType.SHAPES_VARVALUES, SEED),21));
 
-		Collection<Object[]> tests = new Vector<Object[]>();
+		Collection<Object[]> tests = new ArrayList<Object[]>();
 		
 
 		File root = new File(RESOURCES);

--- a/core/combinatorialtesting/ctruntime/src/test/java/org/overture/ct/ctruntime/tests/util/TestSourceFinder.java
+++ b/core/combinatorialtesting/ctruntime/src/test/java/org/overture/ct/ctruntime/tests/util/TestSourceFinder.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.lex.Dialect;
 import org.overture.ct.ctruntime.tests.CtTestCaseBase;
@@ -55,7 +56,7 @@ public class TestSourceFinder
 				if (file.isDirectory() && !file.getName().startsWith("."))
 				{
 					//tests.addAll(createCompleteFile(dialect, name, file, testRoot, extensions));
-					List<File> specFiles = new Vector<File>();
+					List<File> specFiles = new ArrayList<File>();
 					for (File f : file.listFiles())
 					{
 						if(isNotAcceptedFile(f, Arrays.asList(extensions)))
@@ -297,7 +298,7 @@ public class TestSourceFinder
 
 	protected static List<String> readFile(File file) throws IOException
 	{
-		List<String> lines = new Vector<String>();
+		List<String> lines = new ArrayList<String>();
 		BufferedReader reader = null;
 
 		try

--- a/core/interpreter/src/main/java/CSV.java
+++ b/core/interpreter/src/main/java/CSV.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.expressions.PExp;
 import org.overture.ast.lex.Dialect;
@@ -186,7 +187,7 @@ public class CSV extends IO implements Serializable
 		BufferedReader bufRdr = new BufferedReader(new FileReader(file));
 		String line = null;
 		int lineIndex = 0;
-		List<String> cells = new Vector<String>();
+		List<String> cells = new ArrayList<String>();
 
 		if (index < 1)
 		{

--- a/core/interpreter/src/main/java/TestRunner.java
+++ b/core/interpreter/src/main/java/TestRunner.java
@@ -1,5 +1,6 @@
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.SClassDefinition;
 import org.overture.interpreter.runtime.ClassInterpreter;
@@ -15,7 +16,7 @@ public class TestRunner
 {
 	public static Value collectTests(Value obj)
 	{
-		List<String> tests = new Vector<String>();
+		List<String> tests = new ArrayList<String>();
 		ObjectValue instance = (ObjectValue) obj;
 
 		if (ClassInterpreter.getInstance() instanceof ClassInterpreter)

--- a/core/interpreter/src/main/java/TestSuite.java
+++ b/core/interpreter/src/main/java/TestSuite.java
@@ -1,5 +1,6 @@
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.AExplicitOperationDefinition;
 import org.overture.ast.definitions.PDefinition;
@@ -20,7 +21,7 @@ public class TestSuite
 {
 	public static Value getTestMethodNamed(Value test)
 	{
-		List<String> tests = new Vector<String>();
+		List<String> tests = new ArrayList<String>();
 		ObjectValue instance = (ObjectValue) test;
 
 		for (NameValuePair p : instance.members.asList())
@@ -45,7 +46,7 @@ public class TestSuite
 
 	public static Value createTests(Value test) throws Exception
 	{
-		List<String> tests = new Vector<String>();
+		List<String> tests = new ArrayList<String>();
 		ValueList vals = new ValueList();
 		ObjectValue instance = (ObjectValue) test;
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/VDMJ.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/VDMJ.java
@@ -25,6 +25,7 @@ package org.overture.interpreter;
 
 import java.io.File;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -82,8 +83,8 @@ abstract public class VDMJ
 	@SuppressWarnings("unchecked")
 	public static void main(String[] args)
 	{
-		List<File> filenames = new Vector<File>();
-		List<File> pathnames = new Vector<File>();
+		List<File> filenames = new ArrayList<File>();
+		List<File> pathnames = new ArrayList<File>();
 		List<String> largs = Arrays.asList(args);
 		VDMJ controller = null;
 		Dialect dialect = Dialect.VDM_SL;

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/definition/SClassDefinitionAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/definition/SClassDefinitionAssistantInterpreter.java
@@ -1,6 +1,7 @@
 package org.overture.interpreter.assistant.definition;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -175,7 +176,7 @@ public class SClassDefinitionAssistantInterpreter extends
 		setStaticDefinitions(node, ctxt.getGlobal()); // When static member := new X()
 		setStaticValues(node, ctxt.getGlobal()); // When static member := new X()
 
-		List<ObjectValue> inherited = new Vector<ObjectValue>();
+		List<ObjectValue> inherited = new ArrayList<ObjectValue>();
 		NameValuePairMap members = new NameValuePairMap();
 
 		for (SClassDefinition sdef : node.getSuperDefs())

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/expression/PExpAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/expression/PExpAssistantInterpreter.java
@@ -3,6 +3,7 @@ package org.overture.interpreter.assistant.expression;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.assistant.IAstAssistant;
@@ -70,7 +71,7 @@ public class PExpAssistantInterpreter implements IAstAssistant
 			return exp.apply(af.getSubExpressionsLocator());// FIXME: should we handle exceptions like this
 		} catch (AnalysisException e)
 		{
-			List<PExp> subs = new Vector<PExp>();
+			List<PExp> subs = new ArrayList<PExp>();
 			subs.add(exp);
 			return subs;
 		}

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/pattern/AMapPatternMapletAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/pattern/AMapPatternMapletAssistantInterpreter.java
@@ -1,5 +1,6 @@
 package org.overture.interpreter.assistant.pattern;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Vector;
@@ -30,7 +31,7 @@ public class AMapPatternMapletAssistantInterpreter implements IAstAssistant
 	{
 		List<NameValuePairList> flist = af.createPPatternAssistant().getAllNamedValues(p.getFrom(), maplet.getKey(), ctxt);
 		List<NameValuePairList> tlist = af.createPPatternAssistant().getAllNamedValues(p.getTo(), maplet.getValue(), ctxt);
-		List<NameValuePairList> results = new Vector<NameValuePairList>();
+		List<NameValuePairList> results = new ArrayList<NameValuePairList>();
 
 		for (NameValuePairList f : flist)
 		{
@@ -48,7 +49,7 @@ public class AMapPatternMapletAssistantInterpreter implements IAstAssistant
 
 	public List<AIdentifierPattern> findIdentifiers(AMapletPatternMaplet p)
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		list.addAll(af.createPPatternAssistant().findIdentifiers(p.getFrom()));
 		list.addAll(af.createPPatternAssistant().findIdentifiers(p.getTo()));

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/pattern/PPatternAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/pattern/PPatternAssistantInterpreter.java
@@ -2,6 +2,7 @@ package org.overture.interpreter.assistant.pattern;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.assistant.IAstAssistant;
@@ -66,7 +67,7 @@ public class PPatternAssistantInterpreter extends PPatternAssistantTC implements
 			return pattern.apply(af.getIdentifierPatternFinder());// FIXME: should we handle exceptions like this
 		} catch (AnalysisException e)
 		{
-			return new Vector<AIdentifierPattern>(); // Most have none
+			return new ArrayList<AIdentifierPattern>(); // Most have none
 		}
 
 	}

--- a/core/interpreter/src/main/java/org/overture/interpreter/commands/DebuggerReader.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/commands/DebuggerReader.java
@@ -26,6 +26,7 @@ package org.overture.interpreter.commands;
 import java.io.File;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.intf.lex.ILexLocation;
 import org.overture.ast.messages.InternalException;
@@ -89,7 +90,7 @@ public class DebuggerReader extends CommandReader
 				throw new InternalException(52, "Cannot set default name at breakpoint");
 			}
 
-			ExitStatus status = super.run(new Vector<File>());
+			ExitStatus status = super.run(new ArrayList<File>());
 
 			return status;
 		}

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPExecProcesser.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPExecProcesser.java
@@ -10,6 +10,7 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.interpreter.commands.ClassCommandReader;
 import org.overture.interpreter.commands.ModuleCommandReader;
@@ -44,7 +45,7 @@ public class DBGPExecProcesser
 
 		Interpreter i = interpreter;
 		final DBGPReader d = reader;
-		List<File> fileList = new Vector<File>(i.getSourceFiles());
+		List<File> fileList = new ArrayList<File>(i.getSourceFiles());
 		final Writer result = new StringWriter();
 		final Reader input = new StringReader(command);
 		// System.out.println("Command session started in " + new File(".").getAbsolutePath());

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReader.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReader.java
@@ -37,6 +37,7 @@ import java.net.SocketException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -147,7 +148,7 @@ public class DBGPReader
 		String ideKey = null;
 		Settings.dialect = null;
 		String expression = null;
-		List<File> files = new Vector<File>();
+		List<File> files = new ArrayList<File>();
 		List<String> largs = Arrays.asList(args);
 		VDMJ controller = null;
 		boolean warnings = true;
@@ -1089,7 +1090,7 @@ public class DBGPReader
 	{
 		// "<type> [<options>] [-- <base64 args>]"
 
-		List<DBGPOption> options = new Vector<DBGPOption>();
+		List<DBGPOption> options = new ArrayList<DBGPOption>();
 		String args = null;
 		boolean doneOpts = false;
 		boolean gotXID = false;

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReaderV2.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReaderV2.java
@@ -42,6 +42,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.AMutexSyncDefinition;
@@ -150,7 +151,7 @@ public class DBGPReaderV2 extends DBGPReader implements Serializable
 		String ideKey = null;
 		Settings.dialect = null;
 		String expression = null;
-		List<File> files = new Vector<File>();
+		List<File> files = new ArrayList<File>();
 		List<String> largs = Arrays.asList(args);
 		VDMJ controller = null;
 		boolean warnings = true;

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/RemoteInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/RemoteInterpreter.java
@@ -25,6 +25,7 @@ package org.overture.interpreter.debug;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
@@ -148,7 +149,7 @@ public class RemoteInterpreter
 
 	public List<String> getModules() throws Exception
 	{
-		List<String> names = new Vector<String>();
+		List<String> names = new ArrayList<String>();
 
 		if (interpreter instanceof ClassInterpreter)
 		{
@@ -166,7 +167,7 @@ public class RemoteInterpreter
 
 	public List<String> getClasses() throws Exception
 	{
-		List<String> names = new Vector<String>();
+		List<String> names = new ArrayList<String>();
 
 		if (interpreter instanceof ClassInterpreter)
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/eval/StatementEvaluator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/eval/StatementEvaluator.java
@@ -1,5 +1,6 @@
 package org.overture.interpreter.eval;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Vector;
@@ -231,7 +232,7 @@ public class StatementEvaluator extends DelegateExpressionEvaluator
 		try
 		{
 			ctxt.threadState.setAtomic(true);
-			List<ValueListenerList> listenerLists = new Vector<ValueListenerList>(size);
+			List<ValueListenerList> listenerLists = new ArrayList<ValueListenerList>(size);
 
 			for (int i = 0; i < size; i++)
 			{
@@ -283,7 +284,7 @@ public class StatementEvaluator extends DelegateExpressionEvaluator
 			}
 			
 			// Work out the actual types of the arguments, so we bind the right op/fn
-			List<PType> argTypes = new Vector<PType>();
+			List<PType> argTypes = new ArrayList<PType>();
 			int arg = 0;
 			
 			for (PType argType: node.getField().getTypeQualifier())

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/ClassInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/ClassInterpreter.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.ANamedTraceDefinition;
@@ -448,7 +449,7 @@ public class ClassInterpreter extends Interpreter
 	public List<Object> runOneTrace(ANamedTraceDefinition tracedef,
 			CallSequence test, boolean debug) throws AnalysisException
 	{
-		List<Object> list = new Vector<Object>();
+		List<Object> list = new ArrayList<Object>();
 		Context ctxt = null;
 
 		try

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/CollectedContextException.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/CollectedContextException.java
@@ -3,6 +3,7 @@ package org.overture.interpreter.runtime;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 public class CollectedContextException extends ContextException implements
 		ICollectedRuntimeExceptions
@@ -21,7 +22,7 @@ public class CollectedContextException extends ContextException implements
 	public CollectedContextException(ContextException toThrow,
 			Set<ContextException> problems)
 	{
-		this(toThrow, new Vector<Exception>(problems));
+		this(toThrow, new ArrayList<Exception>(problems));
 	}
 
 	/**

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/CollectedExceptions.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/CollectedExceptions.java
@@ -1,5 +1,6 @@
 package org.overture.interpreter.runtime;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
@@ -16,7 +17,7 @@ public class CollectedExceptions extends RuntimeException implements
 
 	public CollectedExceptions(Set<ContextException> problems)
 	{
-		this(new Vector<Exception>(problems));
+		this(new ArrayList<Exception>(problems));
 	}
 
 	/**

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/ModuleInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/ModuleInterpreter.java
@@ -24,6 +24,7 @@
 package org.overture.interpreter.runtime;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
@@ -361,7 +362,7 @@ public class ModuleInterpreter extends Interpreter
 	public List<Object> runOneTrace(ANamedTraceDefinition tracedef,
 			CallSequence test, boolean debug)
 	{
-		List<Object> list = new Vector<Object>();
+		List<Object> list = new ArrayList<Object>();
 		Context ctxt = null;
 
 		try

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/TimingInvariantsParser.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/TimingInvariantsParser.java
@@ -89,7 +89,7 @@ public class TimingInvariantsParser
 
 	private List<ConjectureDefinition> parse(String contents)
 	{
-		List<ConjectureDefinition> defs = new Vector<ConjectureDefinition>();
+		List<ConjectureDefinition> defs = new ArrayList<ConjectureDefinition>();
 
 		try
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/BasicSchedulableThread.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/BasicSchedulableThread.java
@@ -24,6 +24,7 @@
 package org.overture.interpreter.scheduler;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
@@ -198,7 +199,7 @@ public class BasicSchedulableThread implements Serializable
 	{
 		synchronized (allThreads)
 		{
-			List<ISchedulableThread> list = new Vector<ISchedulableThread>();
+			List<ISchedulableThread> list = new ArrayList<ISchedulableThread>();
 
 			for (ISchedulableThread th : allThreads)
 			{

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/CTMainThread.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/CTMainThread.java
@@ -25,6 +25,7 @@ package org.overture.interpreter.scheduler;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.intf.lex.ILexLocation;
 import org.overture.ast.statements.PStm;
@@ -47,7 +48,7 @@ public class CTMainThread extends MainThread
 	private final CallSequence test;
 	private final boolean debug;
 
-	private List<Object> result = new Vector<Object>();
+	private List<Object> result = new ArrayList<Object>();
 
 	public CTMainThread(CallSequence test, Context ctxt, boolean debug)
 	{

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/ConcurrentTraceNode.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/ConcurrentTraceNode.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.interpreter.traces.util.LazyTestSequence;
 import org.overture.interpreter.traces.util.Pair;
@@ -51,7 +52,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 		}
 		Pair<Integer, Integer> v = indics.get(index);
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new ArrayList<TestSequence>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)
@@ -128,7 +129,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 
 		int size = 0;
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new ArrayList<TestSequence>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/ReducedTestSequence.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/ReducedTestSequence.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Random;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.interpreter.traces.util.RandomList;
 
@@ -125,7 +126,7 @@ public class ReducedTestSequence extends TestSequence
 
 				if (subset == null)
 				{
-					subset = new Vector<Integer>();
+					subset = new ArrayList<Integer>();
 					map.put(shape, subset);
 				}
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/SequenceTraceNode.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/SequenceTraceNode.java
@@ -23,6 +23,7 @@
 
 package org.overture.interpreter.traces;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +53,7 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 
 		CallSequence seq = getVariables();
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new ArrayList<TestSequence>();
 		int count = nodes.size();
 
 		// TODO not good, poor performance
@@ -91,7 +92,7 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 
 		indics = new HashMap<Integer, Integer[]>();
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new ArrayList<TestSequence>();
 		int count = nodes.size();
 		int[] sizes = new int[count];
 		int n = 0;

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/TraceExpander.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/TraceExpander.java
@@ -2,6 +2,7 @@ package org.overture.interpreter.traces;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -63,7 +64,7 @@ public class TraceExpander extends QuestionAnswerAdaptor<Context, TraceNode>
 			throws AnalysisException
 	{
 		// return AApplyExpressionTraceCoreDefinitionAssistantInterpreter.expand(core, ctxt);
-		List<PExp> newargs = new Vector<PExp>();
+		List<PExp> newargs = new ArrayList<PExp>();
 		List<PExp> args = null;
 
 		if (core.getCallStatement() instanceof ACallStm)

--- a/core/interpreter/src/main/java/org/overture/interpreter/util/ClassListInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/util/ClassListInterpreter.java
@@ -5,6 +5,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.ABusClassDefinition;
@@ -227,7 +228,7 @@ public class ClassListInterpreter extends ClassList
 			// before we can deploy to them in the constructor. We have to
 			// predict the CPU numbers at this point.
 
-			List<PDefinition> cpudefs = new Vector<PDefinition>();
+			List<PDefinition> cpudefs = new ArrayList<PDefinition>();
 			ACpuClassDefinition instance = null;
 
 			for (PDefinition d : systemClass.getDefinitions())

--- a/core/interpreter/src/main/java/org/overture/interpreter/util/Delegate.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/util/Delegate.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.AExplicitFunctionDefinition;
 import org.overture.ast.definitions.AExplicitOperationDefinition;
@@ -120,7 +121,7 @@ public class Delegate implements Serializable
 
 			// FIXME: this is to handle inheritance in the same way as VDMJ did. See CSV and IO, where the subclass
 			// declared methods is in the tail of the list
-			List<PDefinition> defs = new Vector<PDefinition>(definitions);
+			List<PDefinition> defs = new ArrayList<PDefinition>(definitions);
 			Collections.reverse(defs);
 
 			for (PDefinition d : defs)
@@ -158,7 +159,7 @@ public class Delegate implements Serializable
 			}
 
 			LexNameList anames = new LexNameList();
-			List<Class<?>> ptypes = new Vector<Class<?>>();
+			List<Class<?>> ptypes = new ArrayList<Class<?>>();
 
 			if (plist != null)
 			{

--- a/core/interpreter/src/main/java/org/overture/interpreter/utilities/expression/SubExpressionsLocator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/utilities/expression/SubExpressionsLocator.java
@@ -2,6 +2,7 @@ package org.overture.interpreter.utilities.expression;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.AnswerAdaptor;
@@ -32,7 +33,7 @@ public class SubExpressionsLocator extends AnswerAdaptor<List<PExp>>
 	@Override
 	public List<PExp> caseAApplyExp(AApplyExp exp) throws AnalysisException
 	{
-		List<PExp> subs = new Vector<PExp>();
+		List<PExp> subs = new ArrayList<PExp>();
 		subs.addAll(exp.getRoot().apply(THIS));
 		subs.add(exp);
 		return subs;
@@ -106,7 +107,7 @@ public class SubExpressionsLocator extends AnswerAdaptor<List<PExp>>
 	@Override
 	public List<PExp> defaultPExp(PExp exp) throws AnalysisException
 	{
-		List<PExp> subs = new Vector<PExp>();
+		List<PExp> subs = new ArrayList<PExp>();
 		subs.add(exp);
 		return subs;
 	}

--- a/core/interpreter/src/main/java/org/overture/interpreter/utilities/pattern/AllNamedValuesLocator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/utilities/pattern/AllNamedValuesLocator.java
@@ -1,5 +1,6 @@
 package org.overture.interpreter.utilities.pattern;
 
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -82,7 +83,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseABooleanPattern(ABooleanPattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 
 		try
 		{
@@ -104,7 +105,7 @@ public class AllNamedValuesLocator
 			ACharacterPattern pattern, Newquestion question)
 			throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 
 		try
 		{
@@ -153,7 +154,7 @@ public class AllNamedValuesLocator
 		// generate a set of splits of the values, and offer these to sub-matches
 		// to see whether they fit. Otherwise, there is just one split at this level.
 
-		List<Integer> leftSizes = new Vector<Integer>();
+		List<Integer> leftSizes = new ArrayList<Integer>();
 
 		if (llen == PPatternAssistantInterpreter.ANY)
 		{
@@ -208,7 +209,7 @@ public class AllNamedValuesLocator
 		// Now loop through the various splits and attempt to match the l/r
 		// sub-patterns to the split sequence value.
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new ArrayList<NameValuePairList>();
 
 		for (Integer lsize : leftSizes)
 		{
@@ -227,7 +228,7 @@ public class AllNamedValuesLocator
 				tail.add(iter.next());
 			}
 
-			List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+			List<List<NameValuePairList>> nvplists = new ArrayList<List<NameValuePairList>>();
 			int psize = 2;
 			int[] counts = new int[psize];
 
@@ -295,7 +296,7 @@ public class AllNamedValuesLocator
 			AExpressionPattern pattern, Newquestion question)
 			throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 
 		try
 		{
@@ -321,7 +322,7 @@ public class AllNamedValuesLocator
 			AIdentifierPattern pattern, Newquestion question)
 			throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 		NameValuePairList list = new NameValuePairList();
 		list.add(new NameValuePair(pattern.getName(), question.expval));
 		result.add(list);
@@ -332,7 +333,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseAIgnorePattern(AIgnorePattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 		result.add(new NameValuePairList());
 		return result;
 	}
@@ -341,7 +342,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseAIntegerPattern(AIntegerPattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 
 		try
 		{
@@ -390,11 +391,11 @@ public class AllNamedValuesLocator
 			allMaps = values.permutedMaps();
 		} else
 		{
-			allMaps = new Vector<ValueMap>();
+			allMaps = new ArrayList<ValueMap>();
 			allMaps.add(values);
 		}
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new ArrayList<NameValuePairList>();
 		int psize = pattern.getMaplets().size();
 
 		if (pattern.getMaplets().isEmpty())
@@ -407,7 +408,7 @@ public class AllNamedValuesLocator
 		{
 			Iterator<Entry<Value, Value>> iter = mapPerm.entrySet().iterator();
 
-			List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+			List<List<NameValuePairList>> nvplists = new ArrayList<List<NameValuePairList>>();
 			int[] counts = new int[psize];
 			int i = 0;
 
@@ -501,7 +502,7 @@ public class AllNamedValuesLocator
 		// generate a set of splits of the values, and offer these to sub-matches
 		// to see whether they fit. Otherwise, there is just one split at this level.
 
-		List<Integer> leftSizes = new Vector<Integer>();
+		List<Integer> leftSizes = new ArrayList<Integer>();
 
 		if (llen == PPatternAssistantInterpreter.ANY)
 		{
@@ -566,14 +567,14 @@ public class AllNamedValuesLocator
 			allMaps = values.permutedMaps();
 		} else
 		{
-			allMaps = new Vector<ValueMap>();
+			allMaps = new ArrayList<ValueMap>();
 			allMaps.add(values);
 		}
 
 		// Now loop through the various splits and attempt to match the l/r
 		// sub-patterns to the split map value.
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new ArrayList<NameValuePairList>();
 
 		for (Integer lsize : leftSizes)
 		{
@@ -596,7 +597,7 @@ public class AllNamedValuesLocator
 					second.put(e.getKey(), e.getValue());
 				}
 
-				List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+				List<List<NameValuePairList>> nvplists = new ArrayList<List<NameValuePairList>>();
 				int psize = 2;
 				int[] counts = new int[psize];
 
@@ -665,7 +666,7 @@ public class AllNamedValuesLocator
 			Newquestion question) throws AnalysisException
 	{
 		// return ANilPatternAssistantInterpreter.getAllNamedValues(pattern, question.expval, question.ctxt);
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 
 		if (!(question.expval.deref() instanceof NilValue))
 		{
@@ -680,7 +681,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseAQuotePattern(AQuotePattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 
 		try
 		{
@@ -701,7 +702,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseARealPattern(ARealPattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 
 		try
 		{
@@ -746,7 +747,7 @@ public class AllNamedValuesLocator
 		}
 
 		Iterator<FieldValue> iter = fields.iterator();
-		List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+		List<List<NameValuePairList>> nvplists = new ArrayList<List<NameValuePairList>>();
 		int psize = pattern.getPlist().size();
 		int[] counts = new int[psize];
 		int i = 0;
@@ -759,7 +760,7 @@ public class AllNamedValuesLocator
 		}
 
 		Permutor permutor = new Permutor(counts);
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new ArrayList<NameValuePairList>();
 
 		if (pattern.getPlist().isEmpty())
 		{
@@ -829,7 +830,7 @@ public class AllNamedValuesLocator
 		}
 
 		ListIterator<Value> iter = values.listIterator();
-		List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+		List<List<NameValuePairList>> nvplists = new ArrayList<List<NameValuePairList>>();
 		int psize = pattern.getPlist().size();
 		int[] counts = new int[psize];
 		int i = 0;
@@ -842,7 +843,7 @@ public class AllNamedValuesLocator
 		}
 
 		Permutor permutor = new Permutor(counts);
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new ArrayList<NameValuePairList>();
 
 		if (pattern.getPlist().isEmpty())
 		{
@@ -925,11 +926,11 @@ public class AllNamedValuesLocator
 			allSets = values.permutedSets();
 		} else
 		{
-			allSets = new Vector<ValueSet>();
+			allSets = new ArrayList<ValueSet>();
 			allSets.add(values);
 		}
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new ArrayList<NameValuePairList>();
 		int psize = pattern.getPlist().size();
 
 		if (pattern.getPlist().isEmpty())
@@ -942,7 +943,7 @@ public class AllNamedValuesLocator
 		{
 			Iterator<Value> iter = setPerm.iterator();
 
-			List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+			List<List<NameValuePairList>> nvplists = new ArrayList<List<NameValuePairList>>();
 			int[] counts = new int[psize];
 			int i = 0;
 
@@ -1008,7 +1009,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseAStringPattern(AStringPattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new ArrayList<NameValuePairList>();
 
 		try
 		{
@@ -1045,7 +1046,7 @@ public class AllNamedValuesLocator
 		}
 
 		ListIterator<Value> iter = values.listIterator();
-		List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+		List<List<NameValuePairList>> nvplists = new ArrayList<List<NameValuePairList>>();
 		int psize = pattern.getPlist().size();
 		int[] counts = new int[psize];
 		int i = 0;
@@ -1059,7 +1060,7 @@ public class AllNamedValuesLocator
 		}
 
 		Permutor permutor = new Permutor(counts);
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new ArrayList<NameValuePairList>();
 
 		while (permutor.hasNext())
 		{
@@ -1134,7 +1135,7 @@ public class AllNamedValuesLocator
 		// generate a set of splits of the values, and offer these to sub-matches
 		// to see whether they fit. Otherwise, there is just one split at this level.
 
-		List<Integer> leftSizes = new Vector<Integer>();
+		List<Integer> leftSizes = new ArrayList<Integer>();
 
 		if (llen == PPatternAssistantInterpreter.ANY)
 		{
@@ -1199,14 +1200,14 @@ public class AllNamedValuesLocator
 			allSets = values.permutedSets();
 		} else
 		{
-			allSets = new Vector<ValueSet>();
+			allSets = new ArrayList<ValueSet>();
 			allSets.add(values);
 		}
 
 		// Now loop through the various splits and attempt to match the l/r
 		// sub-patterns to the split set value.
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new ArrayList<NameValuePairList>();
 
 		for (Integer lsize : leftSizes)
 		{
@@ -1227,7 +1228,7 @@ public class AllNamedValuesLocator
 					second.add(iter.next());
 				}
 
-				List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+				List<List<NameValuePairList>> nvplists = new ArrayList<List<NameValuePairList>>();
 				int psize = 2;
 				int[] counts = new int[psize];
 
@@ -1311,7 +1312,7 @@ public class AllNamedValuesLocator
 			VdmRuntimeError.patternFail(4114, "Object type does not match pattern", pattern.getLocation());
 		}
 
-		List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+		List<List<NameValuePairList>> nvplists = new ArrayList<List<NameValuePairList>>();
 		int psize = pattern.getFields().size();
 		int[] counts = new int[psize];
 		int i = 0;
@@ -1331,7 +1332,7 @@ public class AllNamedValuesLocator
 		}
 
 		Permutor permutor = new Permutor(counts);
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new ArrayList<NameValuePairList>();
 
 		if (pattern.getFields().isEmpty())
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/utilities/pattern/IdentifierPatternFinder.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/utilities/pattern/IdentifierPatternFinder.java
@@ -2,6 +2,7 @@ package org.overture.interpreter.utilities.pattern;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.AnswerAdaptor;
@@ -41,7 +42,7 @@ public class IdentifierPatternFinder extends
 			AConcatenationPattern pattern) throws AnalysisException
 	{
 
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		list.addAll(pattern.getLeft().apply(THIS));
 		list.addAll(pattern.getRight().apply(THIS));
@@ -52,7 +53,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> caseAIdentifierPattern(
 			AIdentifierPattern pattern) throws AnalysisException
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 		list.add(pattern);
 		return list;
 	}
@@ -61,7 +62,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> caseAMapPattern(AMapPattern pattern)
 			throws AnalysisException
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		for (AMapletPatternMaplet p : pattern.getMaplets())
 		{
@@ -75,7 +76,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> caseAMapUnionPattern(
 			AMapUnionPattern pattern) throws AnalysisException
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		list.addAll(pattern.getLeft().apply(THIS));
 		list.addAll(pattern.getRight().apply(THIS));
@@ -86,7 +87,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> caseARecordPattern(ARecordPattern pattern)
 			throws AnalysisException
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		for (PPattern p : pattern.getPlist())
 		{
@@ -100,7 +101,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> caseASeqPattern(ASeqPattern pattern)
 			throws AnalysisException
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		for (PPattern p : pattern.getPlist())
 		{
@@ -114,7 +115,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> caseASetPattern(ASetPattern pattern)
 			throws AnalysisException
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		for (PPattern p : pattern.getPlist())
 		{
@@ -128,7 +129,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> caseATuplePattern(ATuplePattern pattern)
 			throws AnalysisException
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		for (PPattern p : pattern.getPlist())
 		{
@@ -142,7 +143,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> caseAUnionPattern(AUnionPattern pattern)
 			throws AnalysisException
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		list.addAll(pattern.getLeft().apply(THIS));
 		list.addAll(pattern.getRight().apply(THIS));
@@ -153,7 +154,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> caseAObjectPattern(AObjectPattern pattern)
 			throws AnalysisException
 	{
-		List<AIdentifierPattern> list = new Vector<AIdentifierPattern>();
+		List<AIdentifierPattern> list = new ArrayList<AIdentifierPattern>();
 
 		for (ANamePatternPair npp : pattern.getFields())
 		{
@@ -167,7 +168,7 @@ public class IdentifierPatternFinder extends
 	public List<AIdentifierPattern> defaultPPattern(PPattern node)
 			throws AnalysisException
 	{
-		return new Vector<AIdentifierPattern>(); // Most have none
+		return new ArrayList<AIdentifierPattern>(); // Most have none
 	}
 
 	@Override

--- a/core/interpreter/src/main/java/org/overture/interpreter/utilities/type/AllValuesCollector.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/utilities/type/AllValuesCollector.java
@@ -2,6 +2,7 @@ package org.overture.interpreter.utilities.type;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -162,7 +163,7 @@ public class AllValuesCollector extends
 	public ValueList caseARecordInvariantType(ARecordInvariantType type,
 			Context ctxt) throws AnalysisException
 	{
-		List<PType> types = new Vector<PType>();
+		List<PType> types = new ArrayList<PType>();
 
 		for (AFieldField f : type.getFields())
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/BUSValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/BUSValue.java
@@ -23,6 +23,7 @@
 
 package org.overture.interpreter.values;
 
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
@@ -51,7 +52,7 @@ public class BUSValue extends ObjectValue
 	public BUSValue(AClassType classtype, NameValuePairMap map,
 			ValueList argvals)
 	{
-		super(classtype, map, new Vector<ObjectValue>(), null, null);
+		super(classtype, map, new ArrayList<ObjectValue>(), null, null);
 
 		QuoteValue parg = (QuoteValue) argvals.get(0);
 		SchedulingPolicy policy = SchedulingPolicy.factory(parg.value.toUpperCase());
@@ -60,7 +61,7 @@ public class BUSValue extends ObjectValue
 		double speed = sarg.value;
 
 		SetValue set = (SetValue) argvals.get(2);
-		List<CPUResource> cpulist = new Vector<CPUResource>();
+		List<CPUResource> cpulist = new ArrayList<CPUResource>();
 
 		for (Value v : set.values)
 		{
@@ -74,8 +75,8 @@ public class BUSValue extends ObjectValue
 
 	public BUSValue(AClassType type, ValueSet cpus)
 	{
-		super(type, new NameValuePairMap(), new Vector<ObjectValue>(), null, null);
-		List<CPUResource> cpulist = new Vector<CPUResource>();
+		super(type, new NameValuePairMap(), new ArrayList<ObjectValue>(), null, null);
+		List<CPUResource> cpulist = new ArrayList<CPUResource>();
 
 		for (Value v : cpus)
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/CPUValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/CPUValue.java
@@ -23,6 +23,7 @@
 
 package org.overture.interpreter.values;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Vector;
 
@@ -46,22 +47,22 @@ public class CPUValue extends ObjectValue
 	public CPUValue(AClassType aClassType, NameValuePairMap map,
 			ValueList argvals)
 	{
-		super(aClassType, map, new Vector<ObjectValue>(), null, null);
+		super(aClassType, map, new ArrayList<ObjectValue>(), null, null);
 
 		QuoteValue parg = (QuoteValue) argvals.get(0);
 		SchedulingPolicy cpup = SchedulingPolicy.factory(parg.value.toUpperCase());
 		RealValue sarg = (RealValue) argvals.get(1);
 
 		resource = new CPUResource(cpup, sarg.value);
-		deployed = new Vector<ObjectValue>();
+		deployed = new ArrayList<ObjectValue>();
 
 	}
 
 	public CPUValue(AClassType classtype) // for virtual CPUs
 	{
-		super(classtype, new NameValuePairMap(), new Vector<ObjectValue>(), null, null);
+		super(classtype, new NameValuePairMap(), new ArrayList<ObjectValue>(), null, null);
 		resource = new CPUResource(new FCFSPolicy(), 0);
-		deployed = new Vector<ObjectValue>();
+		deployed = new ArrayList<ObjectValue>();
 	}
 
 	public void setup(ResourceScheduler scheduler, String name)

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/FunctionValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/FunctionValue.java
@@ -33,6 +33,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Stack;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.assistant.pattern.PTypeList;
@@ -626,7 +627,7 @@ public class FunctionValue extends Value
 			Map<String, String> stateExps = new HashMap<String, String>();
 
 			Interpreter interpreter = Interpreter.getInstance();
-			List<PDefinition> allDefs = new Vector<PDefinition>();
+			List<PDefinition> allDefs = new ArrayList<PDefinition>();
 			if (interpreter instanceof ClassInterpreter)
 			{
 				for (SClassDefinition c : ((ClassInterpreter) interpreter).getClasses())

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ObjectValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ObjectValue.java
@@ -28,6 +28,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map.Entry;
@@ -439,7 +440,7 @@ public class ObjectValue extends Value
 			return mycopy;
 		}
 
-		mycopy = new ObjectValue(type, new NameValuePairMap(), new Vector<ObjectValue>(), CPU, creator);
+		mycopy = new ObjectValue(type, new NameValuePairMap(), new ArrayList<ObjectValue>(), CPU, creator);
 
 		List<ObjectValue> supers = mycopy.superobjects;
 		NameValuePairMap memcopy = mycopy.members;
@@ -447,7 +448,7 @@ public class ObjectValue extends Value
 		for (ObjectValue sobj : superobjects)
 		{
 			supers.add( // Type skeleton only...
-			new ObjectValue(sobj.type, new NameValuePairMap(), new Vector<ObjectValue>(), sobj.CPU, creator));
+			new ObjectValue(sobj.type, new NameValuePairMap(), new ArrayList<ObjectValue>(), sobj.CPU, creator));
 		}
 
 		for (ILexNameToken name : members.keySet())

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/OperationValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/OperationValue.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.AExplicitOperationDefinition;
@@ -530,7 +531,7 @@ public class OperationValue extends Value
 			}
 
 			Interpreter interpreter = Interpreter.getInstance();
-			List<PDefinition> allDefs = new Vector<PDefinition>();
+			List<PDefinition> allDefs = new ArrayList<PDefinition>();
 			if (interpreter instanceof ClassInterpreter)
 			{
 				for (SClassDefinition c : ((ClassInterpreter) interpreter).getClasses())

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ValueFactory.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ValueFactory.java
@@ -23,6 +23,7 @@
 
 package org.overture.interpreter.values;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
@@ -138,7 +139,7 @@ public class ValueFactory
 	public RecordValue createRecord(String recordName, Object... fields)
 			throws ValueFactoryException
 	{
-		List<Value> values = new Vector<Value>();
+		List<Value> values = new ArrayList<Value>();
 		for (Object object : fields)
 		{
 			if (object instanceof Boolean)

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ValueMap.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ValueMap.java
@@ -23,6 +23,7 @@
 
 package org.overture.interpreter.values;
 
+import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -100,7 +101,7 @@ public class ValueMap extends LinkedHashMap<Value, Value>
 		// This is a 1st order permutation, which does not take account of the possible
 		// nesting of maps or the presence of other permutable values with them (sets).
 
-		List<ValueMap> results = new Vector<ValueMap>();
+		List<ValueMap> results = new ArrayList<ValueMap>();
 		Object[] entries = entrySet().toArray();
 		int size = entries.length;
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ValueSet.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ValueSet.java
@@ -23,6 +23,7 @@
 
 package org.overture.interpreter.values;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -144,7 +145,7 @@ public class ValueSet extends Vector<Value> // NB based on Vector
 		// This is a 1st order permutation, which does not take account of the possible
 		// nesting of sets or the presence of other permutable values with them (maps).
 
-		List<ValueSet> results = new Vector<ValueSet>();
+		List<ValueSet> results = new ArrayList<ValueSet>();
 		int size = size();
 
 		if (size == 0)
@@ -173,7 +174,7 @@ public class ValueSet extends Vector<Value> // NB based on Vector
 
 	public List<ValueSet> powerSet()
 	{
-		List<ValueSet> sets = new Vector<ValueSet>(2 ^ size());
+		List<ValueSet> sets = new ArrayList<ValueSet>(2 ^ size());
 
 		if (isEmpty())
 		{

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/CommonInterpreterTest.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/CommonInterpreterTest.java
@@ -8,6 +8,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.junit.Assert;
 import org.junit.Assume;
@@ -81,7 +82,7 @@ public abstract class CommonInterpreterTest extends StringBasedInterpreterTest
 			try
 			{
 				Value val = InterpreterUtil.interpret(Settings.dialect, entry, file);
-				result = new Result<String>(val.toString(), new Vector<IMessage>(), new Vector<IMessage>());
+				result = new Result<String>(val.toString(), new ArrayList<IMessage>(), new Vector<IMessage>());
 				System.out.println(file.getName() + " -> " + val);
 			} catch (Exception e)
 			{
@@ -191,7 +192,7 @@ public abstract class CommonInterpreterTest extends StringBasedInterpreterTest
 	private List<String> getEntries() throws IOException
 	{
 		BufferedReader reader = new BufferedReader(new FileReader(getEntryFile()));
-		List<String> data = new Vector<String>();
+		List<String> data = new ArrayList<String>();
 		String text = null;
 		while ((text = reader.readLine()) != null)
 		{

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/newtests/ParamInterpreterTest.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/newtests/ParamInterpreterTest.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.junit.Assert;
 import org.overture.ast.node.INode;
@@ -75,7 +76,7 @@ public abstract class ParamInterpreterTest extends
 		Vector<Message> errors = new Vector<Message>();
 		String message = e.getMessage();
 		if (e instanceof ICollectedRuntimeExceptions) {
-			List<String> messages = new Vector<String>();
+			List<String> messages = new ArrayList<String>();
 			List<Exception> collectedExceptions = new ArrayList<Exception>(
 					((ICollectedRuntimeExceptions) e).getCollectedExceptions());
 			for (Exception err : collectedExceptions) {
@@ -108,7 +109,7 @@ public abstract class ParamInterpreterTest extends
 	private List<String> getEntries() throws IOException {
 		BufferedReader reader = new BufferedReader(new FileReader(
 				getEntryFile()));
-		List<String> data = new Vector<String>();
+		List<String> data = new ArrayList<String>();
 		String text = null;
 		while ((text = reader.readLine()) != null) {
 			data.add(text.trim());

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/utils/TestSourceFinder.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/utils/TestSourceFinder.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.lex.Dialect;
 
@@ -239,7 +240,7 @@ public class TestSourceFinder
 
 	protected static List<String> readFile(File file) throws IOException
 	{
-		List<String> lines = new Vector<String>();
+		List<String> lines = new ArrayList<String>();
 		BufferedReader reader = null;
 
 		try

--- a/core/interpreter/src/test/java_/ConvertAst.java
+++ b/core/interpreter/src/test/java_/ConvertAst.java
@@ -125,7 +125,7 @@ public class ConvertAst extends BasicTypeCheckTestCase
 		public List<? extends ClonableFile> convert(
 				List<? extends org.overture.util.ClonableFile> node)
 		{
-			List<ClonableFile> files = new Vector<ClonableFile>();
+			List<ClonableFile> files = new ArrayList<ClonableFile>();
 			for (org.overture.util.ClonableFile clonableFile : node)
 			{
 				files.add(new ClonableFile(clonableFile));

--- a/core/parser/src/main/java/org/overture/parser/lex/LexTokenReader.java
+++ b/core/parser/src/main/java/org/overture/parser/lex/LexTokenReader.java
@@ -27,6 +27,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Stack;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.intf.lex.ILexLocation;
 import org.overture.ast.lex.Dialect;
@@ -1205,7 +1206,7 @@ public class LexTokenReader extends BacktrackInputReader
 
 	private List<String> rdName()
 	{
-		List<String> names = new Vector<String>();
+		List<String> names = new ArrayList<String>();
 		names.add(rdIdentifier());
 
 		if (ch == '`')
@@ -1224,7 +1225,7 @@ public class LexTokenReader extends BacktrackInputReader
 
 			if (first.startsWith("mk_") || first.startsWith("is_"))
 			{
-				List<String> one = new Vector<String>();
+				List<String> one = new ArrayList<String>();
 				one.add(first + "`" + names.get(1));
 				names = one;
 			}

--- a/core/parser/src/main/java/org/overture/parser/syntax/BindReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/BindReader.java
@@ -25,6 +25,7 @@ package org.overture.parser.syntax;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.factory.AstFactory;
 import org.overture.ast.lex.VDMToken;
@@ -154,7 +155,7 @@ public class BindReader extends SyntaxReader
 	public List<ATypeBind> readTypeBindList() throws ParserException,
 			LexException
 	{
-		List<ATypeBind> list = new Vector<ATypeBind>();
+		List<ATypeBind> list = new ArrayList<ATypeBind>();
 		list.add(readTypeBind());
 
 		while (ignore(VDMToken.COMMA))
@@ -199,7 +200,7 @@ public class BindReader extends SyntaxReader
 	public List<PMultipleBind> readBindList() throws ParserException,
 			LexException
 	{
-		List<PMultipleBind> list = new Vector<PMultipleBind>();
+		List<PMultipleBind> list = new ArrayList<PMultipleBind>();
 		list.add(readMultipleBind());
 
 		while (ignore(VDMToken.COMMA))

--- a/core/parser/src/main/java/org/overture/parser/syntax/ClassReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/ClassReader.java
@@ -25,6 +25,7 @@ package org.overture.parser.syntax;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.ASystemClassDefinition;
 import org.overture.ast.definitions.PDefinition;
@@ -173,7 +174,7 @@ public class ClassReader extends SyntaxReader
 				throwMessage(2280, "System class cannot be a subclass");
 			}
 
-			List<PDefinition> members = new Vector<PDefinition>();
+			List<PDefinition> members = new ArrayList<PDefinition>();
 			DefinitionReader dr = getDefinitionReader();
 
 			while (lastToken().is(VDMToken.INSTANCE)

--- a/core/parser/src/main/java/org/overture/parser/syntax/DefinitionReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/DefinitionReader.java
@@ -26,6 +26,7 @@ package org.overture.parser.syntax;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.AAssignmentDefinition;
 import org.overture.ast.definitions.AEqualsDefinition;
@@ -118,7 +119,7 @@ public class DefinitionReader extends SyntaxReader
 	public List<PDefinition> readDefinitions() throws ParserException,
 			LexException
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		boolean threadDone = false;
 
 		while (lastToken().isNot(VDMToken.EOF)
@@ -387,7 +388,7 @@ public class DefinitionReader extends SyntaxReader
 	private List<PDefinition> readTypes() throws LexException, ParserException
 	{
 		checkFor(VDMToken.TYPES, 2013, "Expected 'types'");
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 
 		while (!newSection())
 		{
@@ -417,7 +418,7 @@ public class DefinitionReader extends SyntaxReader
 	private List<PDefinition> readValues() throws LexException, ParserException
 	{
 		checkFor(VDMToken.VALUES, 2013, "Expected 'values'");
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 
 		while (!newSection())
 		{
@@ -457,7 +458,7 @@ public class DefinitionReader extends SyntaxReader
 			ParserException
 	{
 		checkFor(VDMToken.FUNCTIONS, 2013, "Expected 'functions'");
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 
 		while (!newSection())
 		{
@@ -495,7 +496,7 @@ public class DefinitionReader extends SyntaxReader
 			ParserException
 	{
 		checkFor(VDMToken.OPERATIONS, 2013, "Expected 'operations'");
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 
 		while (!newSection())
 		{
@@ -525,7 +526,7 @@ public class DefinitionReader extends SyntaxReader
 	{
 		checkFor(VDMToken.INSTANCE, 2083, "Expected 'instance variables'");
 		checkFor(VDMToken.VARIABLES, 2083, "Expecting 'instance variables'");
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 
 		while (!newSection())
 		{
@@ -550,7 +551,7 @@ public class DefinitionReader extends SyntaxReader
 	private List<PDefinition> readTraces() throws LexException, ParserException
 	{
 		checkFor(VDMToken.TRACES, 2013, "Expected 'traces'");
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 
 		while (!newSection())
 		{
@@ -575,7 +576,7 @@ public class DefinitionReader extends SyntaxReader
 	private List<PDefinition> readSyncs() throws LexException, ParserException
 	{
 		checkFor(VDMToken.SYNC, 2013, "Expected 'sync'");
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 
 		while (!newSection())
 		{
@@ -680,7 +681,7 @@ public class DefinitionReader extends SyntaxReader
 			throwMessage(2020, "Expecting '(' after function name");
 		}
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
 
 		while (lastToken().is(VDMToken.BRA))
 		{
@@ -690,7 +691,7 @@ public class DefinitionReader extends SyntaxReader
 				checkFor(VDMToken.KET, 2091, "Expecting ')' after function parameters");
 			} else
 			{
-				parameters.add(new Vector<PPattern>()); // empty "()"
+				parameters.add(new ArrayList<PPattern>()); // empty "()"
 				nextToken();
 			}
 		}
@@ -734,7 +735,7 @@ public class DefinitionReader extends SyntaxReader
 
 		PatternReader pr = getPatternReader();
 		TypeReader tr = getTypeReader();
-		List<APatternListTypePair> parameterPatterns = new Vector<APatternListTypePair>();
+		List<APatternListTypePair> parameterPatterns = new ArrayList<APatternListTypePair>();
 
 		if (lastToken().isNot(VDMToken.KET))
 		{
@@ -753,8 +754,8 @@ public class DefinitionReader extends SyntaxReader
 		checkFor(VDMToken.KET, 2124, "Expecting ')' after parameters");
 
 		LexToken firstResult = lastToken();
-		List<PPattern> resultNames = new Vector<PPattern>();
-		List<PType> resultTypes = new Vector<PType>();
+		List<PPattern> resultNames = new ArrayList<PPattern>();
+		List<PType> resultTypes = new ArrayList<PType>();
 
 		do
 		{
@@ -966,7 +967,7 @@ public class DefinitionReader extends SyntaxReader
 			checkFor(VDMToken.KET, 2101, "Expecting ')' after operation parameters");
 		} else
 		{
-			parameters = new Vector<PPattern>(); // empty "()"
+			parameters = new ArrayList<PPattern>(); // empty "()"
 			nextToken();
 		}
 
@@ -998,7 +999,7 @@ public class DefinitionReader extends SyntaxReader
 		nextToken();
 		PatternReader pr = getPatternReader();
 		TypeReader tr = getTypeReader();
-		List<APatternListTypePair> parameterPatterns = new Vector<APatternListTypePair>();
+		List<APatternListTypePair> parameterPatterns = new ArrayList<APatternListTypePair>();
 
 		if (lastToken().isNot(VDMToken.KET))
 		{
@@ -1021,8 +1022,8 @@ public class DefinitionReader extends SyntaxReader
 
 		if (firstResult.is(VDMToken.IDENTIFIER))
 		{
-			List<PPattern> resultNames = new Vector<PPattern>();
-			List<PType> resultTypes = new Vector<PType>();
+			List<PPattern> resultNames = new ArrayList<PPattern>();
+			List<PType> resultTypes = new ArrayList<PType>();
 
 			do
 			{
@@ -1068,7 +1069,7 @@ public class DefinitionReader extends SyntaxReader
 
 		if (lastToken().is(VDMToken.EXTERNAL))
 		{
-			externals = new Vector<AExternalClause>();
+			externals = new ArrayList<AExternalClause>();
 			nextToken();
 
 			while (lastToken().is(VDMToken.READ)
@@ -1110,7 +1111,7 @@ public class DefinitionReader extends SyntaxReader
 
 		if (lastToken().is(VDMToken.ERRS))
 		{
-			errors = new Vector<AErrorCase>();
+			errors = new ArrayList<AErrorCase>();
 			nextToken();
 
 			while (lastToken() instanceof LexIdentifierToken)
@@ -1363,7 +1364,7 @@ public class DefinitionReader extends SyntaxReader
 	private List<String> readTraceIdentifierList() throws ParserException,
 			LexException
 	{
-		List<String> names = new Vector<String>();
+		List<String> names = new ArrayList<String>();
 		names.add(readIdToken("Expecting trace identifier").getName());
 
 		while (lastToken().is(VDMToken.DIVIDE))
@@ -1378,7 +1379,7 @@ public class DefinitionReader extends SyntaxReader
 	private List<ATraceDefinitionTerm> readTraceDefinitionList()
 			throws LexException, ParserException
 	{
-		List<ATraceDefinitionTerm> list = new Vector<ATraceDefinitionTerm>();
+		List<ATraceDefinitionTerm> list = new ArrayList<ATraceDefinitionTerm>();
 		list.add(readTraceDefinitionTerm());
 
 		while (lastToken().is(VDMToken.SEMICOLON))
@@ -1402,7 +1403,7 @@ public class DefinitionReader extends SyntaxReader
 	private ATraceDefinitionTerm readTraceDefinitionTerm() throws LexException,
 			ParserException
 	{
-		List<PTraceDefinition> term = new Vector<PTraceDefinition>();
+		List<PTraceDefinition> term = new ArrayList<PTraceDefinition>();
 		term.add(readTraceDefinition());
 
 		while (lastToken().is(VDMToken.PIPE))
@@ -1529,7 +1530,7 @@ public class DefinitionReader extends SyntaxReader
 	private PTraceDefinition readLetDefBinding() throws ParserException,
 			LexException
 	{
-		List<AValueDefinition> localDefs = new Vector<AValueDefinition>();
+		List<AValueDefinition> localDefs = new ArrayList<AValueDefinition>();
 		LexToken start = lastToken();
 
 		PDefinition def = readLocalDefinition(NameScope.LOCAL);
@@ -1609,7 +1610,7 @@ public class DefinitionReader extends SyntaxReader
 			case PIPEPIPE:
 				nextToken();
 				checkFor(VDMToken.BRA, 2292, "Expecting '|| (...)'");
-				List<PTraceDefinition> defs = new Vector<PTraceDefinition>();
+				List<PTraceDefinition> defs = new ArrayList<PTraceDefinition>();
 				defs.add(readTraceDefinition());
 				checkFor(VDMToken.COMMA, 2293, "Expecting '|| (a, b {,...})'");
 				defs.add(readTraceDefinition());

--- a/core/parser/src/main/java/org/overture/parser/syntax/ExpressionReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/ExpressionReader.java
@@ -25,6 +25,7 @@ package org.overture.parser.syntax;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.PDefinition;
 import org.overture.ast.expressions.ACaseAlternative;
@@ -726,7 +727,7 @@ public class ExpressionReader extends SyntaxReader
 
 				case SEQ_OPEN:
 					// Polymorphic function instantiation
-					List<PType> types = new Vector<PType>();
+					List<PType> types = new ArrayList<PType>();
 					TypeReader tr = getTypeReader();
 
 					nextToken();
@@ -968,7 +969,7 @@ public class ExpressionReader extends SyntaxReader
 	private AMuExp readMuExpression(AVariableExp ve) throws ParserException,
 			LexException
 	{
-		List<ARecordModifier> args = new Vector<ARecordModifier>();
+		List<ARecordModifier> args = new ArrayList<ARecordModifier>();
 		PExp record = readExpression();
 
 		do
@@ -1192,7 +1193,7 @@ public class ExpressionReader extends SyntaxReader
 	private APreExp readPreExpression(AVariableExp ve) throws ParserException,
 			LexException
 	{
-		List<PExp> args = new Vector<PExp>();
+		List<PExp> args = new ArrayList<PExp>();
 		PExp function = readExpression();
 
 		while (ignore(VDMToken.COMMA))
@@ -1311,7 +1312,7 @@ public class ExpressionReader extends SyntaxReader
 			result = AstFactory.newAMapCompMapExp(start, first, bindings, exp);
 		} else
 		{
-			List<AMapletExp> members = new Vector<AMapletExp>();
+			List<AMapletExp> members = new ArrayList<AMapletExp>();
 			members.add(first);
 
 			while (ignore(VDMToken.COMMA))
@@ -1387,7 +1388,7 @@ public class ExpressionReader extends SyntaxReader
 		PExp exp = readExpression();
 		checkFor(VDMToken.THEN, 2144, "Missing 'then'");
 		PExp thenExp = readExpression();
-		List<AElseIfExp> elseList = new Vector<AElseIfExp>();
+		List<AElseIfExp> elseList = new ArrayList<AElseIfExp>();
 
 		while (lastToken().is(VDMToken.ELSEIF))
 		{
@@ -1424,7 +1425,7 @@ public class ExpressionReader extends SyntaxReader
 		PExp exp = readExpression();
 		checkFor(VDMToken.COLON, 2146, "Expecting ':' after cases expression");
 
-		List<ACaseAlternative> cases = new Vector<ACaseAlternative>();
+		List<ACaseAlternative> cases = new ArrayList<ACaseAlternative>();
 		PExp others = null;
 		cases.addAll(readCaseAlternatives(exp));
 
@@ -1449,7 +1450,7 @@ public class ExpressionReader extends SyntaxReader
 	private List<ACaseAlternative> readCaseAlternatives(PExp exp)
 			throws ParserException, LexException
 	{
-		List<ACaseAlternative> alts = new Vector<ACaseAlternative>();
+		List<ACaseAlternative> alts = new ArrayList<ACaseAlternative>();
 		List<PPattern> plist = getPatternReader().readPatternList();
 		checkFor(VDMToken.ARROW, 2149, "Expecting '->' after case pattern list");
 		PExp then = readExpression();
@@ -1499,7 +1500,7 @@ public class ExpressionReader extends SyntaxReader
 	{
 		DefinitionReader dr = getDefinitionReader();
 
-		List<PDefinition> localDefs = new Vector<PDefinition>();
+		List<PDefinition> localDefs = new ArrayList<PDefinition>();
 
 		localDefs.add(dr.readLocalDefinition(NameScope.LOCAL));
 
@@ -1577,7 +1578,7 @@ public class ExpressionReader extends SyntaxReader
 			throws ParserException, LexException
 	{
 		DefinitionReader dr = getDefinitionReader();
-		List<PDefinition> equalsDefs = new Vector<PDefinition>();
+		List<PDefinition> equalsDefs = new ArrayList<PDefinition>();
 
 		while (lastToken().isNot(VDMToken.IN))
 		{

--- a/core/parser/src/main/java/org/overture/parser/syntax/ModuleReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/ModuleReader.java
@@ -26,6 +26,7 @@ package org.overture.parser.syntax;
 import java.io.File;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.ATypeDefinition;
 import org.overture.ast.definitions.PDefinition;
@@ -125,9 +126,9 @@ public class ModuleReader extends SyntaxReader
 
 	public static AFromModuleImports importAll(LexIdentifierToken from)
 	{
-		List<List<PImport>> types = new Vector<List<PImport>>();
+		List<List<PImport>> types = new ArrayList<List<PImport>>();
 		LexNameToken all = new LexNameToken(from.getName(), "all", from.location);
-		List<PImport> impAll = new Vector<PImport>();
+		List<PImport> impAll = new ArrayList<PImport>();
 		impAll.add(AstFactory.newAAllImport(all));
 		types.add(impAll);
 		return AstFactory.newAFromModuleImports(from, types);
@@ -253,7 +254,7 @@ public class ModuleReader extends SyntaxReader
 		}
 
 		// return new DLModule(name, imports, exports, library);
-		List<ClonableFile> files = new Vector<ClonableFile>();
+		List<ClonableFile> files = new ArrayList<ClonableFile>();
 		files.add(new ClonableFile(name.location.getFile()));
 
 		AModuleModules module = AstFactory.newAModuleModules(name, imports, exports, null);
@@ -271,12 +272,12 @@ public class ModuleReader extends SyntaxReader
 	private List<List<PExport>> readExportsFromModule() throws ParserException,
 			LexException
 	{
-		List<List<PExport>> types = new Vector<List<PExport>>();
+		List<List<PExport>> types = new ArrayList<List<PExport>>();
 
 		if (lastToken().is(VDMToken.ALL))
 		{
 			LexNameToken all = new LexNameToken(getCurrentModule(), "all", lastToken().location);
-			List<PExport> expAll = new Vector<PExport>();
+			List<PExport> expAll = new ArrayList<PExport>();
 			expAll.add(AstFactory.newAAllExport(all.location));
 			types.add(expAll);
 			nextToken();
@@ -323,7 +324,7 @@ public class ModuleReader extends SyntaxReader
 	private List<PExport> readExportedTypes() throws ParserException,
 			LexException
 	{
-		List<PExport> list = new Vector<PExport>();
+		List<PExport> list = new ArrayList<PExport>();
 		list.add(readExportedType());
 
 		while (lastToken().isNot(VDMToken.DEFINITIONS)
@@ -350,7 +351,7 @@ public class ModuleReader extends SyntaxReader
 	private List<PExport> readExportedValues() throws ParserException,
 			LexException
 	{
-		List<PExport> list = new Vector<PExport>();
+		List<PExport> list = new ArrayList<PExport>();
 		list.add(readExportedValue());
 
 		while (lastToken().isNot(VDMToken.DEFINITIONS)
@@ -376,7 +377,7 @@ public class ModuleReader extends SyntaxReader
 	private List<PExport> readExportedFunctions() throws ParserException,
 			LexException
 	{
-		List<PExport> list = new Vector<PExport>();
+		List<PExport> list = new ArrayList<PExport>();
 		list.add(readExportedFunction());
 
 		while (lastToken().is(VDMToken.IDENTIFIER)
@@ -410,7 +411,7 @@ public class ModuleReader extends SyntaxReader
 	private List<PExport> readExportedOperations() throws ParserException,
 			LexException
 	{
-		List<PExport> list = new Vector<PExport>();
+		List<PExport> list = new ArrayList<PExport>();
 		list.add(readExportedOperation());
 
 		while (lastToken().is(VDMToken.IDENTIFIER)
@@ -436,7 +437,7 @@ public class ModuleReader extends SyntaxReader
 	private List<ILexNameToken> readIdList() throws ParserException,
 			LexException
 	{
-		List<ILexNameToken> list = new Vector<ILexNameToken>();
+		List<ILexNameToken> list = new ArrayList<ILexNameToken>();
 		list.add(readNameToken("Expecting name list"));
 
 		while (ignore(VDMToken.COMMA))
@@ -451,7 +452,7 @@ public class ModuleReader extends SyntaxReader
 			throws ParserException, LexException
 	{
 		checkFor(VDMToken.IMPORTS, 2178, "Expecting 'imports'");
-		List<AFromModuleImports> imports = new Vector<AFromModuleImports>();
+		List<AFromModuleImports> imports = new ArrayList<AFromModuleImports>();
 		imports.add(readImportDefinition());
 
 		while (ignore(VDMToken.COMMA))
@@ -473,12 +474,12 @@ public class ModuleReader extends SyntaxReader
 	private List<List<PImport>> readImportsFromModule(LexIdentifierToken from)
 			throws ParserException, LexException
 	{
-		List<List<PImport>> types = new Vector<List<PImport>>();
+		List<List<PImport>> types = new ArrayList<List<PImport>>();
 
 		if (lastToken().is(VDMToken.ALL))
 		{
 			LexNameToken all = new LexNameToken(getCurrentModule(), "all", lastToken().location);
-			List<PImport> impAll = new Vector<PImport>();
+			List<PImport> impAll = new ArrayList<PImport>();
 			impAll.add(AstFactory.newAAllImport(all));
 			types.add(impAll);
 			nextToken();
@@ -525,7 +526,7 @@ public class ModuleReader extends SyntaxReader
 	private List<PImport> readImportedTypes(LexIdentifierToken from)
 			throws ParserException, LexException
 	{
-		List<PImport> list = new Vector<PImport>();
+		List<PImport> list = new ArrayList<PImport>();
 		list.add(readImportedType(from));
 
 		while (lastToken().is(VDMToken.IDENTIFIER)
@@ -581,7 +582,7 @@ public class ModuleReader extends SyntaxReader
 	private List<PImport> readImportedValues(LexIdentifierToken from)
 			throws ParserException, LexException
 	{
-		List<PImport> list = new Vector<PImport>();
+		List<PImport> list = new ArrayList<PImport>();
 		list.add(readImportedValue(from));
 
 		while (lastToken().is(VDMToken.IDENTIFIER)
@@ -620,7 +621,7 @@ public class ModuleReader extends SyntaxReader
 	private List<PImport> readImportedFunctions(LexIdentifierToken from)
 			throws ParserException, LexException
 	{
-		List<PImport> list = new Vector<PImport>();
+		List<PImport> list = new ArrayList<PImport>();
 		list.add(readImportedFunction(from));
 
 		while (lastToken().is(VDMToken.IDENTIFIER)
@@ -667,7 +668,7 @@ public class ModuleReader extends SyntaxReader
 	private List<PImport> readImportedOperations(LexIdentifierToken from)
 			throws ParserException, LexException
 	{
-		List<PImport> list = new Vector<PImport>();
+		List<PImport> list = new ArrayList<PImport>();
 		list.add(readImportedOperation(from));
 
 		while (lastToken().is(VDMToken.IDENTIFIER)

--- a/core/parser/src/main/java/org/overture/parser/syntax/PatternReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/PatternReader.java
@@ -25,6 +25,7 @@ package org.overture.parser.syntax;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.factory.AstFactory;
 import org.overture.ast.lex.LexBooleanToken;
@@ -145,12 +146,12 @@ public class PatternReader extends SyntaxReader
 			case SET_OPEN:
 				if (nextToken().is(VDMToken.SET_CLOSE))
 				{
-					pattern = AstFactory.newASetPattern(token.location, new Vector<PPattern>());
+					pattern = AstFactory.newASetPattern(token.location, new ArrayList<PPattern>());
 				} else if (lastToken().is(VDMToken.MAPLET))
 				{
 					if (Settings.release == Release.VDM_10)
 					{
-						pattern = AstFactory.newAMapPattern(token.location, new Vector<AMapletPatternMaplet>());
+						pattern = AstFactory.newAMapPattern(token.location, new ArrayList<AMapletPatternMaplet>());
 						nextToken();
 						checkFor(VDMToken.SET_CLOSE, 2299, "Expecting {|->} empty map pattern");
 						rdtok = false;
@@ -187,7 +188,7 @@ public class PatternReader extends SyntaxReader
 			case SEQ_OPEN:
 				if (nextToken().is(VDMToken.SEQ_CLOSE))
 				{
-					pattern = AstFactory.newASeqPattern(token.location, new Vector<PPattern>());
+					pattern = AstFactory.newASeqPattern(token.location, new ArrayList<PPattern>());
 				} else
 				{
 					pattern = AstFactory.newASeqPattern(token.location, readPatternList());
@@ -235,7 +236,7 @@ public class PatternReader extends SyntaxReader
 						if (lastToken().is(VDMToken.KET))
 						{
 							// An empty pattern list
-							pattern = AstFactory.newARecordPattern(typename, new Vector<PPattern>());
+							pattern = AstFactory.newARecordPattern(typename, new ArrayList<PPattern>());
 							nextToken();
 						} else
 						{
@@ -292,7 +293,7 @@ public class PatternReader extends SyntaxReader
 	private List<AMapletPatternMaplet> readMapletPatternList()
 			throws LexException, ParserException
 	{
-		List<AMapletPatternMaplet> list = new Vector<AMapletPatternMaplet>();
+		List<AMapletPatternMaplet> list = new ArrayList<AMapletPatternMaplet>();
 		list.add(readMaplet());
 
 		while (ignore(VDMToken.COMMA))
@@ -316,7 +317,7 @@ public class PatternReader extends SyntaxReader
 	public List<PPattern> readPatternList() throws ParserException,
 			LexException
 	{
-		List<PPattern> list = new Vector<PPattern>();
+		List<PPattern> list = new ArrayList<PPattern>();
 		list.add(readPattern());
 
 		while (ignore(VDMToken.COMMA))
@@ -339,7 +340,7 @@ public class PatternReader extends SyntaxReader
 
 	private List<ANamePatternPair> readNamePatternList(String classname) throws LexException, ParserException
 	{
-		List<ANamePatternPair> list = new Vector<ANamePatternPair>();
+		List<ANamePatternPair> list = new ArrayList<ANamePatternPair>();
 		
 		if (lastToken().is(VDMToken.IDENTIFIER))	// Can be empty
 		{

--- a/core/parser/src/main/java/org/overture/parser/syntax/StatementReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/StatementReader.java
@@ -25,6 +25,7 @@ package org.overture.parser.syntax;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.AAssignmentDefinition;
 import org.overture.ast.definitions.PDefinition;
@@ -224,7 +225,7 @@ public class StatementReader extends SyntaxReader
 	{
 		checkFor(VDMToken.TIXE, 2191, "Expecting 'tixe'");
 
-		List<ATixeStmtAlternative> traps = new Vector<ATixeStmtAlternative>();
+		List<ATixeStmtAlternative> traps = new ArrayList<ATixeStmtAlternative>();
 		BindReader br = getBindReader();
 		checkFor(VDMToken.SET_OPEN, 2192, "Expecting '{' after 'tixe'");
 
@@ -321,7 +322,7 @@ public class StatementReader extends SyntaxReader
 	{
 		checkFor(VDMToken.ATOMIC, 2203, "Expecting 'atomic'");
 		checkFor(VDMToken.BRA, 2204, "Expecting '(' after 'atomic'");
-		List<AAssignmentStm> assignments = new Vector<AAssignmentStm>();
+		List<AAssignmentStm> assignments = new ArrayList<AAssignmentStm>();
 
 		assignments.add(readAssignmentStatement(lastToken().location));
 		ignore(VDMToken.SEMICOLON); // Every statement has an ignorable semicolon
@@ -352,7 +353,7 @@ public class StatementReader extends SyntaxReader
 		LexNameToken name = readNameToken("Expecting operation name in call statement");
 
 		checkFor(VDMToken.BRA, 2206, "Expecting '(' after call operation name");
-		List<PExp> args = new Vector<PExp>();
+		List<PExp> args = new ArrayList<PExp>();
 		ExpressionReader er = getExpressionReader();
 
 		if (lastToken().isNot(VDMToken.KET))
@@ -445,7 +446,7 @@ public class StatementReader extends SyntaxReader
 				case BRA:
 					nextToken();
 					ExpressionReader er = getExpressionReader();
-					List<PExp> args = new Vector<PExp>();
+					List<PExp> args = new ArrayList<PExp>();
 
 					if (lastToken().isNot(VDMToken.KET))
 					{
@@ -492,7 +493,7 @@ public class StatementReader extends SyntaxReader
 				LexIdentifierToken name = readIdToken("Expecting class name after 'new'");
 				checkFor(VDMToken.BRA, 2207, "Expecting '(' after new class name");
 
-				List<PExp> args = new Vector<PExp>();
+				List<PExp> args = new ArrayList<PExp>();
 				ExpressionReader er = getExpressionReader();
 
 				if (lastToken().isNot(VDMToken.KET))
@@ -628,7 +629,7 @@ public class StatementReader extends SyntaxReader
 		PExp exp = getExpressionReader().readExpression();
 		checkFor(VDMToken.THEN, 2219, "Missing 'then'");
 		PStm thenStmt = readStatement();
-		List<AElseIfStm> elseIfList = new Vector<AElseIfStm>();
+		List<AElseIfStm> elseIfList = new ArrayList<AElseIfStm>();
 
 		while (lastToken().is(VDMToken.ELSEIF))
 		{
@@ -748,7 +749,7 @@ public class StatementReader extends SyntaxReader
 	private List<AAssignmentDefinition> readDclStatements()
 			throws ParserException, LexException
 	{
-		List<AAssignmentDefinition> defs = new Vector<AAssignmentDefinition>();
+		List<AAssignmentDefinition> defs = new ArrayList<AAssignmentDefinition>();
 
 		while (lastToken().is(VDMToken.DCL))
 		{
@@ -856,7 +857,7 @@ public class StatementReader extends SyntaxReader
 			throws ParserException, LexException
 	{
 		DefinitionReader dr = getDefinitionReader();
-		List<PDefinition> localDefs = new Vector<PDefinition>();
+		List<PDefinition> localDefs = new ArrayList<PDefinition>();
 		localDefs.add(dr.readLocalDefinition(NameScope.LOCAL));
 
 		while (ignore(VDMToken.COMMA))
@@ -892,7 +893,7 @@ public class StatementReader extends SyntaxReader
 		PExp exp = getExpressionReader().readExpression();
 		checkFor(VDMToken.COLON, 2235, "Expecting ':' after cases expression");
 
-		List<ACaseAlternativeStm> cases = new Vector<ACaseAlternativeStm>();
+		List<ACaseAlternativeStm> cases = new ArrayList<ACaseAlternativeStm>();
 		PStm others = null;
 		cases.addAll(readCaseAlternatives());
 
@@ -917,7 +918,7 @@ public class StatementReader extends SyntaxReader
 	private List<ACaseAlternativeStm> readCaseAlternatives()
 			throws ParserException, LexException
 	{
-		List<ACaseAlternativeStm> alts = new Vector<ACaseAlternativeStm>();
+		List<ACaseAlternativeStm> alts = new ArrayList<ACaseAlternativeStm>();
 		List<PPattern> plist = getPatternReader().readPatternList();
 		checkFor(VDMToken.ARROW, 2236, "Expecting '->' after case pattern list");
 		PStm result = readStatement();
@@ -936,7 +937,7 @@ public class StatementReader extends SyntaxReader
 	{
 		checkFor(VDMToken.DEF, 2239, "Expecting 'def'");
 		DefinitionReader dr = getDefinitionReader();
-		List<PDefinition> equalsDefs = new Vector<PDefinition>();
+		List<PDefinition> equalsDefs = new ArrayList<PDefinition>();
 
 		while (lastToken().isNot(VDMToken.IN))
 		{

--- a/core/parser/src/main/java/org/overture/parser/syntax/SyntaxReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/SyntaxReader.java
@@ -27,6 +27,7 @@ import java.io.PrintWriter;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.intf.lex.ILexLocation;
 import org.overture.ast.intf.lex.ILexToken;
@@ -616,7 +617,7 @@ public abstract class SyntaxReader
 
 	public List<VDMError> getErrors()
 	{
-		List<VDMError> list = new Vector<VDMError>();
+		List<VDMError> list = new ArrayList<VDMError>();
 
 		for (SyntaxReader rdr : readers)
 		{
@@ -649,7 +650,7 @@ public abstract class SyntaxReader
 
 	public List<VDMWarning> getWarnings()
 	{
-		List<VDMWarning> list = new Vector<VDMWarning>();
+		List<VDMWarning> list = new ArrayList<VDMWarning>();
 
 		for (SyntaxReader rdr : readers)
 		{

--- a/core/parser/src/main/java/org/overture/parser/syntax/TypeReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/TypeReader.java
@@ -25,6 +25,7 @@ package org.overture.parser.syntax;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.factory.AstFactory;
 import org.overture.ast.intf.lex.ILexLocation;
@@ -94,7 +95,7 @@ public class TypeReader extends SyntaxReader
 	{
 		LexToken token = lastToken();
 		PType type = readComposeType();
-		List<PType> productList = new Vector<PType>();
+		List<PType> productList = new ArrayList<PType>();
 		productList.add(type);
 
 		while (lastToken().type == VDMToken.TIMES)
@@ -135,7 +136,7 @@ public class TypeReader extends SyntaxReader
 	public List<AFieldField> readFieldList() throws ParserException,
 			LexException
 	{
-		List<AFieldField> list = new Vector<AFieldField>();
+		List<AFieldField> list = new ArrayList<AFieldField>();
 
 		while (lastToken().isNot(VDMToken.END)
 				&& lastToken().isNot(VDMToken.SEMICOLON)
@@ -389,7 +390,7 @@ public class TypeReader extends SyntaxReader
 
 	private List<PType> productExpand(PType parameters)
 	{
-		List<PType> types = new Vector<PType>();
+		List<PType> types = new ArrayList<PType>();
 
 		if (parameters instanceof AProductType)
 		{

--- a/core/parser/src/test/java/org/overture/parser/tests/framework/BaseParserTestCase.java
+++ b/core/parser/src/test/java/org/overture/parser/tests/framework/BaseParserTestCase.java
@@ -24,6 +24,7 @@ package org.overture.parser.tests.framework;
 import java.io.File;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.lex.Dialect;
 import org.overture.ast.node.INode;
@@ -101,8 +102,8 @@ public abstract class BaseParserTestCase<T extends SyntaxReader, R> extends
 
 			System.out.println();
 
-			List<IMessage> warnings = new Vector<IMessage>();
-			List<IMessage> errors = new Vector<IMessage>();
+			List<IMessage> warnings = new ArrayList<IMessage>();
+			List<IMessage> errors = new ArrayList<IMessage>();
 
 			collectParserErrorsAndWarnings(reader, errors, warnings);
 			Result<R> resultFinal = new Result<R>(result, warnings, errors);

--- a/core/pog/src/main/java/org/overture/pog/contexts/POCaseContext.java
+++ b/core/pog/src/main/java/org/overture/pog/contexts/POCaseContext.java
@@ -25,6 +25,7 @@ package org.overture.pog.contexts;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.AEqualsDefinition;
 import org.overture.ast.definitions.PDefinition;
@@ -83,7 +84,7 @@ public class POCaseContext extends POContext
 			local.setPattern(pattern.clone());
 			// local.setName(def.getName().clone());
 			local.setTest(exp.clone());
-			List<PDefinition> lDefs = new Vector<PDefinition>();
+			List<PDefinition> lDefs = new ArrayList<PDefinition>();
 			lDefs.add(local);
 			letDefExp.setLocalDefs(lDefs);
 			letDefExp.setExpression(stitch);

--- a/core/pog/src/main/java/org/overture/pog/contexts/POFunctionDefinitionContext.java
+++ b/core/pog/src/main/java/org/overture/pog/contexts/POFunctionDefinitionContext.java
@@ -28,6 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.AExplicitFunctionDefinition;
 import org.overture.ast.definitions.AImplicitFunctionDefinition;
@@ -135,7 +136,7 @@ public class POFunctionDefinitionContext extends POContext {
 
 			for (PPattern param : params) {
 				ATypeMultipleBind typeBind = new ATypeMultipleBind();
-				List<PPattern> one = new Vector<PPattern>();
+				List<PPattern> one = new ArrayList<PPattern>();
 				one.add(param.clone());
 				typeBind.setPlist(one);
 				PType type = types.next();

--- a/core/pog/src/main/java/org/overture/pog/obligation/FiniteMapObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/FiniteMapObligation.java
@@ -25,6 +25,7 @@ package org.overture.pog.obligation;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.expressions.AApplyExp;
@@ -138,7 +139,7 @@ public class FiniteMapObligation extends ProofObligation
 		AApplyExp apply = getApplyExp(getVarExp(finmap), getVarExp(findex));
 
 		AMapEnumMapExp setEnum = new AMapEnumMapExp();
-		List<AMapletExp> members = new Vector<AMapletExp>();
+		List<AMapletExp> members = new ArrayList<AMapletExp>();
 		members.add(exp.getFirst().clone());
 		setEnum.setMembers(members);
 

--- a/core/pog/src/main/java/org/overture/pog/obligation/FuncComposeObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/FuncComposeObligation.java
@@ -25,6 +25,7 @@ package org.overture.pog.obligation;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.expressions.ACompBinaryExp;
@@ -83,7 +84,7 @@ public class FuncComposeObligation extends ProofObligation
 				// pre_(exp.getRight(), arg) =>
 				APreExp preExp = new APreExp();
 				preExp.setFunction(exp.getRight().clone());
-				List<PExp> args = new Vector<PExp>();
+				List<PExp> args = new ArrayList<PExp>();
 				args.add(getVarExp(arg));
 				preExp.setArgs(args);
 
@@ -102,7 +103,7 @@ public class FuncComposeObligation extends ProofObligation
 			// pre_(exp.getLeft(), exp.getRight()(arg))
 			APreExp preExp = new APreExp();
 			preExp.setFunction(exp.getLeft().clone());
-			List<PExp> args = new Vector<PExp>();
+			List<PExp> args = new ArrayList<PExp>();
 			args.add(getApplyExp(exp.getRight().clone(), getVarExp(arg)));
 			preExp.setArgs(args);
 			secondPart = preExp;

--- a/core/pog/src/main/java/org/overture/pog/obligation/LetBeExistsObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/LetBeExistsObligation.java
@@ -25,6 +25,7 @@ package org.overture.pog.obligation;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.expressions.ABooleanConstExp;
@@ -51,7 +52,7 @@ public class LetBeExistsObligation extends ProofObligation
 		 */
 
 		AExistsExp exists = new AExistsExp();
-		List<PMultipleBind> bindList = new Vector<PMultipleBind>();
+		List<PMultipleBind> bindList = new ArrayList<PMultipleBind>();
 		bindList.add(exp.getBind().clone());
 		exists.setBindList(bindList);
 
@@ -78,7 +79,7 @@ public class LetBeExistsObligation extends ProofObligation
 		super(stmt, POType.LET_BE_EXISTS, ctxt, stmt.getBind().getLocation(), af);
 
 		AExistsExp exists = new AExistsExp();
-		List<PMultipleBind> bindList = new Vector<PMultipleBind>();
+		List<PMultipleBind> bindList = new ArrayList<PMultipleBind>();
 		bindList.add(stmt.getBind().clone());
 		exists.setBindList(bindList);
 

--- a/core/pog/src/main/java/org/overture/pog/obligation/MapInjectivityEnum.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/MapInjectivityEnum.java
@@ -25,6 +25,7 @@ package org.overture.pog.obligation;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.expressions.AApplyExp;
@@ -68,12 +69,12 @@ public class MapInjectivityEnum extends ProofObligation
 		somType.setSetof(mapEnumExp.getType().clone());
 		setOfMaplets.setType(somType);
 
-		List<AMapEnumMapExp> singleMaplets = new Vector<AMapEnumMapExp>();
+		List<AMapEnumMapExp> singleMaplets = new ArrayList<AMapEnumMapExp>();
 
 		for (AMapletExp maplet : mapEnumExp.getMembers())
 		{
 			AMapEnumMapExp mapOfOne = new AMapEnumMapExp();
-			List<AMapletExp> members = new Vector<AMapletExp>();
+			List<AMapletExp> members = new ArrayList<AMapletExp>();
 			members.add(maplet.clone());
 			mapOfOne.setMembers(members);
 			mapOfOne.setType(maplet.getType().clone());

--- a/core/pog/src/main/java/org/overture/pog/obligation/ParameterPatternObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/ParameterPatternObligation.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
-import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.AExplicitFunctionDefinition;
@@ -110,8 +110,8 @@ public class ParameterPatternObligation extends ProofObligation
 			List<PType> params, PType result) throws AnalysisException
 	{
 		AForAllExp forallExp = new AForAllExp();
-		List<PMultipleBind> forallBindList = new Vector<PMultipleBind>();
-		List<PExp> arglist = new Vector<PExp>();
+		List<PMultipleBind> forallBindList = new ArrayList<PMultipleBind>();
+		List<PExp> arglist = new ArrayList<PExp>();
 		PExp forallPredicate = null;
 
 		for (List<PPattern> paramList : plist)
@@ -121,7 +121,7 @@ public class ParameterPatternObligation extends ProofObligation
 			if (!paramList.isEmpty())
 			{
 				AExistsExp existsExp = new AExistsExp();
-				List<PMultipleBind> existsBindList = new Vector<PMultipleBind>();
+				List<PMultipleBind> existsBindList = new ArrayList<PMultipleBind>();
 				PExp existsPredicate = null;
 
 				Set<ILexNameToken> previousBindings = new HashSet<ILexNameToken>();

--- a/core/pog/src/main/java/org/overture/pog/obligation/ProofObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/ProofObligation.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.PDefinition;
@@ -242,7 +243,7 @@ abstract public class ProofObligation implements IProofObligation, Serializable
 			ILexNameToken... patternNames)
 	{
 		ATypeMultipleBind typeBind = new ATypeMultipleBind();
-		List<PPattern> patternList = new Vector<PPattern>();
+		List<PPattern> patternList = new ArrayList<PPattern>();
 
 		for (ILexNameToken patternName : patternNames)
 		{
@@ -265,7 +266,7 @@ abstract public class ProofObligation implements IProofObligation, Serializable
 			ILexNameToken... patternNames)
 	{
 		ASetMultipleBind setBind = new ASetMultipleBind();
-		List<PPattern> patternList = new Vector<PPattern>();
+		List<PPattern> patternList = new ArrayList<PPattern>();
 
 		for (ILexNameToken patternName : patternNames)
 		{
@@ -286,7 +287,7 @@ abstract public class ProofObligation implements IProofObligation, Serializable
 	protected List<PMultipleBind> getMultipleTypeBindList(PType patternType,
 			ILexNameToken... patternNames)
 	{
-		List<PMultipleBind> typeBindList = new Vector<PMultipleBind>();
+		List<PMultipleBind> typeBindList = new ArrayList<PMultipleBind>();
 		typeBindList.add(getMultipleTypeBind(patternType, patternNames));
 		return typeBindList;
 	}
@@ -297,7 +298,7 @@ abstract public class ProofObligation implements IProofObligation, Serializable
 	protected List<PMultipleBind> getMultipleSetBindList(PExp setExp,
 			ILexNameToken... patternNames)
 	{
-		List<PMultipleBind> setBindList = new Vector<PMultipleBind>();
+		List<PMultipleBind> setBindList = new ArrayList<PMultipleBind>();
 		setBindList.add(getMultipleSetBind(setExp, patternNames));
 		return setBindList;
 	}
@@ -382,7 +383,7 @@ abstract public class ProofObligation implements IProofObligation, Serializable
 	{
 		AApplyExp apply = new AApplyExp();
 		apply.setRoot(root.clone());
-		List<PExp> args = new Vector<PExp>();
+		List<PExp> args = new ArrayList<PExp>();
 
 		for (PExp arg : arglist)
 		{

--- a/core/pog/src/main/java/org/overture/pog/obligation/SatisfiabilityObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/SatisfiabilityObligation.java
@@ -26,6 +26,7 @@ package org.overture.pog.obligation;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.AClassInvariantDefinition;
@@ -73,7 +74,7 @@ public class SatisfiabilityObligation extends ProofObligation
 		 * f: A * B -> R [pre ...] post ... [pre_f(a, b) =>] exists r:R & post_f(a, b, r)
 		 */
 
-		List<PExp> arglist = new Vector<PExp>();
+		List<PExp> arglist = new ArrayList<PExp>();
 
 		for (APatternListTypePair pltp : func.getParamPatterns())
 		{
@@ -94,7 +95,7 @@ public class SatisfiabilityObligation extends ProofObligation
 
 		AExistsExp existsExp = new AExistsExp();
 		existsExp.setType(new ABooleanBasicType());
-		List<PExp> postArglist = new Vector<PExp>(arglist);
+		List<PExp> postArglist = new ArrayList<PExp>(arglist);
 
 		if (func.getResult().getPattern() instanceof AIdentifierPattern)
 		{
@@ -185,7 +186,7 @@ public class SatisfiabilityObligation extends ProofObligation
 
 	private List<PMultipleBind> getInvBinds(AStateDefinition node)
 	{
-		List<PMultipleBind> r = new Vector<PMultipleBind>();
+		List<PMultipleBind> r = new ArrayList<PMultipleBind>();
 
 		for (AFieldField f : node.getFields())
 		{
@@ -230,7 +231,7 @@ public class SatisfiabilityObligation extends ProofObligation
 	PExp buildPredicate(AImplicitOperationDefinition op,
 			PDefinition stateDefinition) throws AnalysisException
 	{
-		List<PExp> arglist = new Vector<PExp>();
+		List<PExp> arglist = new ArrayList<PExp>();
 
 		for (APatternListTypePair pltp : op.getParameterPatterns())
 		{
@@ -261,7 +262,7 @@ public class SatisfiabilityObligation extends ProofObligation
 
 			AExistsExp existsExp = new AExistsExp();
 			existsExp.setType(new ABooleanBasicType());
-			List<PExp> postArglist = new Vector<PExp>(arglist);
+			List<PExp> postArglist = new ArrayList<PExp>(arglist);
 
 			if (op.getResult().getPattern() instanceof AIdentifierPattern)
 			{
@@ -309,7 +310,7 @@ public class SatisfiabilityObligation extends ProofObligation
 
 			AExistsExp exists_exp = new AExistsExp();
 			exists_exp.setType(new ABooleanBasicType());
-			List<PExp> postArglist = new Vector<PExp>(arglist);
+			List<PExp> postArglist = new ArrayList<PExp>(arglist);
 
 			List<PMultipleBind> exists_binds = new LinkedList<PMultipleBind>();
 			if (stateDefinition != null)
@@ -317,7 +318,7 @@ public class SatisfiabilityObligation extends ProofObligation
 				stateInPost(exists_binds, postArglist, stateDefinition);
 			}
 			exists_exp.setBindList(exists_binds);
-			AApplyExp postApply = getApplyExp(getVarExp(op.getPostdef().getName(),op.getPostdef().clone()), new Vector<PExp>(postArglist));
+			AApplyExp postApply = getApplyExp(getVarExp(op.getPostdef().getName(),op.getPostdef().clone()), new ArrayList<PExp>(postArglist));
 			postApply.setType(new ABooleanBasicType());
 			postApply.getRoot().setType(op.getPostdef().getType().clone());
 			exists_exp.setPredicate(postApply);

--- a/core/pog/src/main/java/org/overture/pog/obligation/StateInvariantObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/StateInvariantObligation.java
@@ -26,6 +26,7 @@ package org.overture.pog.obligation;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.AClassInvariantDefinition;
@@ -79,7 +80,7 @@ public class StateInvariantObligation extends ProofObligation
 			AStateDefinition def = ass.getStateDefinition();
 			ALetDefExp letExp = new ALetDefExp();
 			letExp.setType(def.getInvExpression().getType().clone());
-			List<PDefinition> invDefs = new Vector<PDefinition>();
+			List<PDefinition> invDefs = new ArrayList<PDefinition>();
 			AEqualsDefinition local = new AEqualsDefinition();
 			local.setExpType(def.getRecordType().clone());
 			local.setPattern(def.getInvPattern().clone());
@@ -155,7 +156,7 @@ public class StateInvariantObligation extends ProofObligation
 			return extractInv(atom);
 		}
 		String stateName = getStateName(stateDef);
-		List<PExp> arglist = new Vector<PExp>();
+		List<PExp> arglist = new ArrayList<PExp>();
 		for (AFieldField f : stateDef.getFields())
 		{
 			arglist.add(getVarExp(f.getTagname().clone(), stateDef.clone(),f.getType()));

--- a/core/pog/src/main/java/org/overture/pog/obligation/TypeCompatibilityObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/TypeCompatibilityObligation.java
@@ -464,7 +464,7 @@ public class TypeCompatibilityObligation extends ProofObligation
 				ANotEqualBinaryExp ne = new ANotEqualBinaryExp();
 				ne.setLeft(exp);
 				ASeqEnumSeqExp empty = new ASeqEnumSeqExp();
-				empty.setMembers(new Vector<PExp>());
+				empty.setMembers(new ArrayList<PExp>());
 				ne.setRight(empty);
 			}
 

--- a/core/pog/src/main/java/org/overture/pog/obligation/ValueBindingObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/ValueBindingObligation.java
@@ -25,6 +25,7 @@ package org.overture.pog.obligation;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.AEqualsDefinition;
@@ -64,12 +65,12 @@ public class ValueBindingObligation extends ProofObligation
 		super(pattern, POType.VALUE_BINDING, ctxt, pattern.getLocation(), af);
 		AExistsExp existsExp = new AExistsExp();
 
-		List<PPattern> patternList = new Vector<PPattern>();
+		List<PPattern> patternList = new ArrayList<PPattern>();
 		patternList.add(pattern.clone());
 		ATypeMultipleBind typeBind = new ATypeMultipleBind();
 		typeBind.setPlist(patternList);
 		typeBind.setType(type.clone());
-		List<PMultipleBind> bindList = new Vector<PMultipleBind>();
+		List<PMultipleBind> bindList = new ArrayList<PMultipleBind>();
 		bindList.add(typeBind);
 		existsExp.setBindList(bindList);
 

--- a/core/pog/src/main/java/org/overture/pog/visitors/PatternToExpVisitor.java
+++ b/core/pog/src/main/java/org/overture/pog/visitors/PatternToExpVisitor.java
@@ -2,6 +2,7 @@ package org.overture.pog.visitors;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.AnswerAdaptor;
@@ -180,7 +181,7 @@ public class PatternToExpVisitor extends AnswerAdaptor<PExp>
 	{
 		AMkTypeExp mkExp = new AMkTypeExp();
 		mkExp.setTypeName(node.getTypename().clone());
-		List<PExp> args = new Vector<PExp>();
+		List<PExp> args = new ArrayList<PExp>();
 
 		for (PPattern p : node.getPlist())
 		{
@@ -194,7 +195,7 @@ public class PatternToExpVisitor extends AnswerAdaptor<PExp>
 	public PExp caseATuplePattern(ATuplePattern node) throws AnalysisException
 	{
 		ATupleExp tuple = new ATupleExp();
-		List<PExp> values = new Vector<PExp>();
+		List<PExp> values = new ArrayList<PExp>();
 
 		for (PPattern p : node.getPlist())
 		{
@@ -210,7 +211,7 @@ public class PatternToExpVisitor extends AnswerAdaptor<PExp>
 	public PExp caseASeqPattern(ASeqPattern node) throws AnalysisException
 	{
 		ASeqEnumSeqExp seq = new ASeqEnumSeqExp();
-		List<PExp> values = new Vector<PExp>();
+		List<PExp> values = new ArrayList<PExp>();
 
 		for (PPattern p : node.getPlist())
 		{
@@ -234,7 +235,7 @@ public class PatternToExpVisitor extends AnswerAdaptor<PExp>
 	public PExp caseASetPattern(ASetPattern node) throws AnalysisException
 	{
 		ASetEnumSetExp set = new ASetEnumSetExp();
-		List<PExp> values = new Vector<PExp>();
+		List<PExp> values = new ArrayList<PExp>();
 
 		for (PPattern p : node.getPlist())
 		{
@@ -257,7 +258,7 @@ public class PatternToExpVisitor extends AnswerAdaptor<PExp>
 	public PExp caseAMapPattern(AMapPattern node) throws AnalysisException
 	{
 		AMapEnumMapExp map = new AMapEnumMapExp();
-		List<AMapletExp> values = new Vector<AMapletExp>();
+		List<AMapletExp> values = new ArrayList<AMapletExp>();
 
 		for (AMapletPatternMaplet p : node.getMaplets())
 		{

--- a/core/pog/src/main/java/org/overture/pog/visitors/VariableSubVisitor.java
+++ b/core/pog/src/main/java/org/overture/pog/visitors/VariableSubVisitor.java
@@ -2,6 +2,7 @@ package org.overture.pog.visitors;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -140,7 +141,7 @@ public class VariableSubVisitor extends
 	private List<PExp> distribute(List<PExp> args, Substitution question)
 			throws AnalysisException
 	{
-		List<PExp> subs = new Vector<PExp>();
+		List<PExp> subs = new ArrayList<PExp>();
 		for (PExp a : args)
 		{
 			subs.add(a.clone().apply(main, question));

--- a/core/prettyprinting/prettyprinter/src/main/java/org/overture/prettyprinter/PrettyPrinterVisitorDefinitions.java
+++ b/core/prettyprinting/prettyprinter/src/main/java/org/overture/prettyprinter/PrettyPrinterVisitorDefinitions.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -149,7 +150,7 @@ public class PrettyPrinterVisitorDefinitions extends
 			LinkedList<PDefinition> definitions,
 			Class<? extends PDefinition> pDefClass)
 	{
-		List<PDefinition> result = new Vector<PDefinition>();
+		List<PDefinition> result = new ArrayList<PDefinition>();
 
 		for (PDefinition pDefinition : definitions)
 		{

--- a/core/prettyprinting/prettyprinter/src/main/java/org/overture/prettyprinter/TypePrettyPrinterVisitor.java
+++ b/core/prettyprinting/prettyprinter/src/main/java/org/overture/prettyprinter/TypePrettyPrinterVisitor.java
@@ -23,6 +23,7 @@ package org.overture.prettyprinter;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -110,7 +111,7 @@ public class TypePrettyPrinterVisitor extends
 	public String caseAProductType(AProductType node, PrettyPrinterEnv question)
 			throws AnalysisException
 	{
-		List<String> types = new Vector<String>();
+		List<String> types = new ArrayList<String>();
 		for (PType t : node.getTypes())
 		{
 			types.add(t.apply(this, question));
@@ -129,7 +130,7 @@ public class TypePrettyPrinterVisitor extends
 	public String caseAUnionType(AUnionType node, PrettyPrinterEnv question)
 			throws AnalysisException
 	{
-		List<String> types = new Vector<String>();
+		List<String> types = new ArrayList<String>();
 		for (PType t : node.getTypes())
 		{
 			types.add(t.apply(this, question));

--- a/core/testframework/src/main/java/org/overture/test/framework/BaseTestSuite.java
+++ b/core/testframework/src/main/java/org/overture/test/framework/BaseTestSuite.java
@@ -30,6 +30,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import junit.framework.Test;
 import junit.framework.TestSuite;
@@ -290,7 +291,7 @@ public class BaseTestSuite extends TestSuite
 
 	protected static List<String> readFile(File file) throws IOException
 	{
-		List<String> lines = new Vector<String>();
+		List<String> lines = new ArrayList<String>();
 		BufferedReader reader = null;
 
 		try

--- a/core/testframework/src/main/java/org/overture/test/framework/ResultTestCase.java
+++ b/core/testframework/src/main/java/org/overture/test/framework/ResultTestCase.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -162,8 +163,8 @@ public abstract class ResultTestCase<R> extends BaseTestCase implements
 	protected <T> Result<T> mergeResults(Set<? extends Result<T>> parse,
 			IResultCombiner<T> c)
 	{
-		List<IMessage> warnings = new Vector<IMessage>();
-		List<IMessage> errors = new Vector<IMessage>();
+		List<IMessage> warnings = new ArrayList<IMessage>();
+		List<IMessage> errors = new ArrayList<IMessage>();
 		T result = null;
 
 		for (Result<T> r : parse)

--- a/core/testframework/src/main/java/org/overture/test/framework/ResultTestCase4.java
+++ b/core/testframework/src/main/java/org/overture/test/framework/ResultTestCase4.java
@@ -27,6 +27,7 @@ import java.io.PrintWriter;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -179,8 +180,8 @@ public abstract class ResultTestCase4<R> implements IResultStore<R>
 	protected <T> Result<T> mergeResults(Set<? extends Result<T>> parse,
 			IResultCombiner<T> c)
 	{
-		List<IMessage> warnings = new Vector<IMessage>();
-		List<IMessage> errors = new Vector<IMessage>();
+		List<IMessage> warnings = new ArrayList<IMessage>();
+		List<IMessage> errors = new ArrayList<IMessage>();
 		T result = null;
 
 		for (Result<T> r : parse)

--- a/core/testframework/src/main/java/org/overture/test/util/MessageReaderWriter.java
+++ b/core/testframework/src/main/java/org/overture/test/util/MessageReaderWriter.java
@@ -30,6 +30,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.test.framework.results.IMessage;
 import org.overture.test.framework.results.Message;
@@ -47,8 +48,8 @@ public class MessageReaderWriter
 	public static String ERROR_LABEL = "ERROR";
 	public static String RESULT_LABEL = "RESULT";
 
-	final List<IMessage> errors = new Vector<IMessage>();
-	final List<IMessage> warnings = new Vector<IMessage>();
+	final List<IMessage> errors = new ArrayList<IMessage>();
+	final List<IMessage> warnings = new ArrayList<IMessage>();
 	String result = "";
 	final File file;
 

--- a/core/testframework/src/main/java/org/overture/test/util/XmlResultReaderWriter.java
+++ b/core/testframework/src/main/java/org/overture/test/util/XmlResultReaderWriter.java
@@ -24,6 +24,7 @@ package org.overture.test.util;
 import java.io.File;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -168,8 +169,8 @@ public class XmlResultReaderWriter<R>
 	public boolean loadFromXml()
 	{
 		// File resultFile = new File(file.getAbsoluteFile()+ ".result");
-		List<IMessage> warnings = new Vector<IMessage>();
-		List<IMessage> errors = new Vector<IMessage>();
+		List<IMessage> warnings = new ArrayList<IMessage>();
+		List<IMessage> errors = new ArrayList<IMessage>();
 		R readResult = null;
 
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();

--- a/core/testing/extests/src/test/java/org/overture/core/tests/ParseTcAllExamplesTest.java
+++ b/core/testing/extests/src/test/java/org/overture/core/tests/ParseTcAllExamplesTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,7 +40,7 @@ public class ParseTcAllExamplesTest
 	@Parameters(name = "{index} : {0}")
 	public static Collection<Object[]> testData() throws IOException, URISyntaxException
 	{
-		Collection<Object[]> r = new Vector<Object[]>();
+		Collection<Object[]> r = new ArrayList<Object[]>();
 
 		Collection<ExampleSourceData> examples = ExamplesUtility.getExamplesSources(EXAMPLES_ROOT);
 

--- a/core/testing/extests/src/test/java/org/overture/core/tests/ParseTcLibsTest.java
+++ b/core/testing/extests/src/test/java/org/overture/core/tests/ParseTcLibsTest.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.util.Collection;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -38,7 +39,7 @@ public class ParseTcLibsTest
 	@Parameters(name = "{index} : {0}")
 	public static Collection<Object[]> testData() throws IOException, URISyntaxException
 	{
-		Collection<Object[]> r = new Vector<Object[]>();
+		Collection<Object[]> r = new ArrayList<Object[]>();
 
 		Collection<ExampleSourceData> examples = ExamplesUtility.getLibSources(LIBS_ROOT);
 

--- a/core/testing/extests/src/test/java/org/overture/core/tests/demos/DefNamesTestResult.java
+++ b/core/testing/extests/src/test/java/org/overture/core/tests/demos/DefNamesTestResult.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.fail;
 import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.apache.commons.collections4.CollectionUtils;
 import org.overture.ast.definitions.PDefinition;
@@ -36,7 +37,7 @@ public class DefNamesTestResult {
 
 	public DefNamesTestResult(List<INode> ast, String name) {
 		this.exampleName = name;
-		defNames = new Vector<String>();
+		defNames = new ArrayList<String>();
 		for (INode n : ast) {
 			if (n instanceof AModuleModules) // ModuleModules prints the file
 												// path so we skip it

--- a/core/testing/framework/src/main/java/org/overture/core/tests/ParamExternalsTest.java
+++ b/core/testing/framework/src/main/java/org/overture/core/tests/ParamExternalsTest.java
@@ -23,6 +23,7 @@ package org.overture.core.tests;
 
 import java.util.Collection;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -77,7 +78,7 @@ public abstract class ParamExternalsTest<R> extends ParamFineGrainTest<R>
 
 		if (external == null)
 		{
-			return new Vector<Object[]>();
+			return new ArrayList<Object[]>();
 		} else
 		{
 			return PathsProvider.computeExternalPaths(external);

--- a/core/testing/framework/src/main/java/org/overture/core/tests/ParseTcFacade.java
+++ b/core/testing/framework/src/main/java/org/overture/core/tests/ParseTcFacade.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.SClassDefinition;
 import org.overture.ast.expressions.PExp;
@@ -246,7 +247,7 @@ public abstract class ParseTcFacade
 			ext = parts[1];
 		}
 		File f = new File(sourcePath);
-		List<File> sources = new Vector<File>();
+		List<File> sources = new ArrayList<File>();
 		sources.add(f);
 
 		if (ext.equals("vdmsl") | ext.equals("vdm"))
@@ -258,7 +259,7 @@ public abstract class ParseTcFacade
 		{
 			if (ext.equals("vdmpp") | ext.equals("vpp"))
 			{
-				List<File> files = new Vector<File>();
+				List<File> files = new ArrayList<File>();
 				files.add(f);
 				return parseTcPpContent(files, testName, true);
 
@@ -266,7 +267,7 @@ public abstract class ParseTcFacade
 			{
 				if (ext.equals("vdmrt"))
 				{
-					List<File> files = new Vector<File>();
+					List<File> files = new ArrayList<File>();
 					files.add(f);
 					return parseTcRtContent(files, testName, true);
 				} else

--- a/core/testing/framework/src/main/java/org/overture/core/tests/PathsProvider.java
+++ b/core/testing/framework/src/main/java/org/overture/core/tests/PathsProvider.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.filefilter.DirectoryFileFilter;
@@ -119,7 +120,7 @@ public class PathsProvider
 	{
 		Collection<File> files = FileUtils.listFiles(dir, new RegexFileFilter(EXTERNAL_VDM_EXTENSION_REGEX), DirectoryFileFilter.DIRECTORY);
 
-		List<Object[]> paths = new Vector<Object[]>();
+		List<Object[]> paths = new ArrayList<Object[]>();
 
 		for (File file : files)
 		{
@@ -155,7 +156,7 @@ public class PathsProvider
 	{
 		Collection<File> files = FileUtils.listFiles(dir, new RegexFileFilter(VDM_EXTENSION_REGEX), DirectoryFileFilter.DIRECTORY);
 
-		List<Object[]> paths = new Vector<Object[]>();
+		List<Object[]> paths = new ArrayList<Object[]>();
 
 		for (File file : files)
 		{

--- a/core/testing/tests/src/test/java/org/overture/core/tests/demos/ExternalsDemoTest.java
+++ b/core/testing/tests/src/test/java/org/overture/core/tests/demos/ExternalsDemoTest.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -167,7 +168,7 @@ public class ExternalsDemoTest extends ParamExternalsTest<IdTestResult> {
 				modelPath));
 		if (pr.errors.isEmpty()) {
 			ITypeCheckerAssistantFactory af = new TypeCheckerAssistantFactory();
-			List<SClassDefinition> classes = new Vector<SClassDefinition>();
+			List<SClassDefinition> classes = new ArrayList<SClassDefinition>();
 			classes.addAll(pr.result);
 			classes.add(AstFactoryTC.newACpuClassDefinition(af));
 			classes.add(AstFactoryTC.newABusClassDefinition(af));

--- a/core/typechecker/src/main/java/org/overture/typechecker/ModuleTypeChecker.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/ModuleTypeChecker.java
@@ -25,6 +25,7 @@ package org.overture.typechecker;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.PDefinition;
@@ -169,8 +170,8 @@ public class ModuleTypeChecker extends TypeChecker
 		// Create a list of all definitions from all modules, including
 		// imports of renamed definitions.
 
-		List<PDefinition> alldefs = new Vector<PDefinition>();
-		List<PDefinition> checkDefs = new Vector<PDefinition>();
+		List<PDefinition> alldefs = new ArrayList<PDefinition>();
+		List<PDefinition> checkDefs = new ArrayList<PDefinition>();
 
 		for (AModuleModules m : modules)
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/TypeComparator.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/TypeComparator.java
@@ -27,6 +27,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.assistant.pattern.PTypeList;
 import org.overture.ast.definitions.ATypeDefinition;
@@ -1077,7 +1078,7 @@ public class TypeComparator
 			return null;
 		} else
 		{
-			List<PType> list = new Vector<PType>();
+			List<PType> list = new ArrayList<PType>();
 			list.addAll(result);
 			return AstFactory.newAUnionType(a.getLocation(), list);
 		}

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AExplicitFunctionDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AExplicitFunctionDefinitionAssistantTC.java
@@ -161,7 +161,7 @@ public class AExplicitFunctionDefinitionAssistantTC implements IAstAssistant
 			AExplicitFunctionDefinition d)
 	{
 
-		List<PPattern> last = new Vector<PPattern>();
+		List<PPattern> last = new ArrayList<PPattern>();
 		int psize = d.getParamPatternList().size();
 
 		for (PPattern p : d.getParamPatternList().get(psize - 1))
@@ -172,7 +172,7 @@ public class AExplicitFunctionDefinitionAssistantTC implements IAstAssistant
 		LexNameToken result = new LexNameToken(d.getName().getModule(), "RESULT", d.getLocation());
 		last.add(AstFactory.newAIdentifierPattern(result));
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
 
 		if (psize > 1)
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AExplicitOperationDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AExplicitOperationDefinitionAssistantTC.java
@@ -57,7 +57,7 @@ public class AExplicitOperationDefinitionAssistantTC implements IAstAssistant
 			AExplicitOperationDefinition node)
 	{
 
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 		Iterator<PType> titer = ((AOperationType) node.getType()).getParameters().iterator();
 
 		for (PPattern p : node.getParameterPatterns())
@@ -73,8 +73,8 @@ public class AExplicitOperationDefinitionAssistantTC implements IAstAssistant
 			AExplicitOperationDefinition d, Environment base)
 	{
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
-		List<PPattern> plist = new Vector<PPattern>();
+		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
+		List<PPattern> plist = new ArrayList<PPattern>();
 		plist.addAll((List<PPattern>) d.getParameterPatterns().clone());
 
 		if (!(((AOperationType) d.getType()).getResult() instanceof AVoidType))
@@ -120,8 +120,8 @@ public class AExplicitOperationDefinitionAssistantTC implements IAstAssistant
 			AExplicitOperationDefinition d, Environment base)
 	{
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
-		List<PPattern> plist = new Vector<PPattern>();
+		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
+		List<PPattern> plist = new ArrayList<PPattern>();
 		plist.addAll((List<PPattern>) d.getParameterPatterns().clone());
 
 		if (d.getState() != null)

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AImplicitOperationDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AImplicitOperationDefinitionAssistantTC.java
@@ -55,8 +55,8 @@ public class AImplicitOperationDefinitionAssistantTC implements IAstAssistant
 			AImplicitOperationDefinition d, Environment base)
 	{
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
-		List<PPattern> plist = new Vector<PPattern>();
+		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
+		List<PPattern> plist = new ArrayList<PPattern>();
 
 		for (APatternListTypePair pl : (LinkedList<APatternListTypePair>) d.getParameterPatterns())
 		{
@@ -103,8 +103,8 @@ public class AImplicitOperationDefinitionAssistantTC implements IAstAssistant
 			AImplicitOperationDefinition d, Environment base)
 	{
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
-		List<PPattern> plist = new Vector<PPattern>();
+		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
+		List<PPattern> plist = new ArrayList<PPattern>();
 
 		for (APatternListTypePair pl : (LinkedList<APatternListTypePair>) d.getParameterPatterns())
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/PDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/PDefinitionAssistantTC.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.intf.IQuestionAnswer;
@@ -396,7 +397,7 @@ public class PDefinitionAssistantTC extends PDefinitionAssistant implements IAst
 			noDuplicates.add(d1);
 		}
 
-		return new Vector<PDefinition>(noDuplicates);
+		return new ArrayList<PDefinition>(noDuplicates);
 	}
 
 	public boolean isSubclassResponsibility(PDefinition d)

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/PDefinitionListAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/PDefinitionListAssistantTC.java
@@ -303,7 +303,7 @@ public class PDefinitionListAssistantTC implements IAstAssistant
 	
 	public List<PDefinition> removeAbstracts(List<PDefinition> list)
 	{
-		List<PDefinition> keep = new Vector<PDefinition>();
+		List<PDefinition> keep = new ArrayList<PDefinition>();
 		PDefinitionAssistantTC assistant = af.createPDefinitionAssistant();
 		
 		for (PDefinition def: list)

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/PDefinitionSet.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/PDefinitionSet.java
@@ -24,6 +24,7 @@ package org.overture.typechecker.assistant.definition;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.definitions.PDefinition;
 import org.overture.typechecker.assistant.ITypeCheckerAssistantFactory;
@@ -70,7 +71,7 @@ public class PDefinitionSet extends HashSet<PDefinition>
 
 	public List<PDefinition> asList()
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		list.addAll(this);
 		return list;
 	}

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/SClassDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/SClassDefinitionAssistantTC.java
@@ -26,6 +26,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -302,12 +303,12 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 
 		PStm body = AstFactory.newAClassInvariantStm(invname, invdefs);
 
-		return AstFactory.newAExplicitOperationDefinition(invname, type, new Vector<PPattern>(), null, null, body);
+		return AstFactory.newAExplicitOperationDefinition(invname, type, new ArrayList<PPattern>(), null, null, body);
 	}
 
 	public List<PDefinition> getInvDefs(SClassDefinition def)
 	{
-		List<PDefinition> invdefs = new Vector<PDefinition>();
+		List<PDefinition> invdefs = new ArrayList<PDefinition>();
 
 		if (def.getGettingInvDefs())
 		{
@@ -336,7 +337,7 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 
 	private void setInheritedDefinitions(SClassDefinition definition)
 	{
-		List<PDefinition> indefs = new Vector<PDefinition>();
+		List<PDefinition> indefs = new ArrayList<PDefinition>();
 
 		for (SClassDefinition sclass : definition.getSuperDefs())
 		{
@@ -347,7 +348,7 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 		// definitions, taken in order, will consider the overriding
 		// members before others.
 
-		List<PDefinition> superInheritedDefinitions = new Vector<PDefinition>();
+		List<PDefinition> superInheritedDefinitions = new ArrayList<PDefinition>();
 
 		for (PDefinition d : indefs)
 		{
@@ -364,7 +365,7 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 		}
 
 		definition.setSuperInheritedDefinitions(superInheritedDefinitions);
-		definition.setAllInheritedDefinitions(new Vector<PDefinition>());
+		definition.setAllInheritedDefinitions(new ArrayList<PDefinition>());
 		definition.getAllInheritedDefinitions().addAll(superInheritedDefinitions);
 		definition.getAllInheritedDefinitions().addAll(definition.getLocalInheritedDefinitions());
 
@@ -373,7 +374,7 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 	private List<PDefinition> getInheritable(SClassDefinition def)
 	{
 
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		if (def.getGettingInheritable())
 		{
@@ -524,7 +525,7 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 		int inheritedThreads = 0;
 		af.createSClassDefinitionAssistant().checkOverloads(c);
 
-		List<List<PDefinition>> superlist = new Vector<List<PDefinition>>();
+		List<List<PDefinition>> superlist = new ArrayList<List<PDefinition>>();
 
 		for (PDefinition def : c.getSuperDefs())
 		{
@@ -659,7 +660,7 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 
 	private void checkOverloads(SClassDefinition c)
 	{
-		List<String> done = new Vector<String>();
+		List<String> done = new ArrayList<String>();
 
 		List<PDefinition> singles = af.createPDefinitionListAssistant().singleDefinitions(c.getDefinitions());
 
@@ -742,7 +743,7 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 				if (d instanceof AValueDefinition)
 				{
 					// ValueDefinition body always a static context
-					FlatCheckedEnvironment checked = new FlatCheckedEnvironment(af, new Vector<PDefinition>(), base, NameScope.NAMES);
+					FlatCheckedEnvironment checked = new FlatCheckedEnvironment(af, new ArrayList<PDefinition>(), base, NameScope.NAMES);
 					checked.setStatic(true);
 					env = checked;
 				}

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/SFunctionDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/SFunctionDefinitionAssistantTC.java
@@ -58,7 +58,7 @@ public class SFunctionDefinitionAssistantTC implements IAstAssistant
 		while (piter.hasNext())
 		{
 			List<PPattern> plist = piter.next();
-			List<PDefinition> defs = new Vector<PDefinition>();
+			List<PDefinition> defs = new ArrayList<PDefinition>();
 			List<PType> ptypes = ftype.getParameters();
 			Iterator<PType> titer = ptypes.iterator();
 

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/module/AModuleImportsAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/module/AModuleImportsAssistantTC.java
@@ -23,6 +23,7 @@ package org.overture.typechecker.assistant.module;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.assistant.IAstAssistant;
@@ -49,7 +50,7 @@ public class AModuleImportsAssistantTC implements IAstAssistant
 	public List<PDefinition> getDefinitions(AModuleImports imports,
 			List<AModuleModules> allModules)
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		for (AFromModuleImports ifm : imports.getImports())
 		{
@@ -89,7 +90,7 @@ public class AModuleImportsAssistantTC implements IAstAssistant
 			AModuleModules from)
 	{
 
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		for (List<PImport> ofType : ifm.getSignatures())
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/module/AModuleModulesAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/module/AModuleModulesAssistantTC.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.assistant.IAstAssistant;
@@ -118,7 +119,7 @@ public class AModuleModulesAssistantTC implements IAstAssistant
 	public Collection<? extends PDefinition> getDefinitions(
 			AModuleExports aModuleExports, LinkedList<PDefinition> actualDefs)
 	{
-		List<PDefinition> exportDefs = new Vector<PDefinition>();
+		List<PDefinition> exportDefs = new ArrayList<PDefinition>();
 
 		for (List<PExport> etype : aModuleExports.getExports())
 		{
@@ -141,7 +142,7 @@ public class AModuleModulesAssistantTC implements IAstAssistant
 	public Collection<? extends PDefinition> getDefinitions(
 			AModuleExports aModuleExports)
 	{
-		List<PDefinition> exportDefs = new Vector<PDefinition>();
+		List<PDefinition> exportDefs = new ArrayList<PDefinition>();
 
 		for (List<PExport> etype : aModuleExports.getExports())
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/pattern/PMultipleBindAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/pattern/PMultipleBindAssistantTC.java
@@ -24,6 +24,7 @@ package org.overture.typechecker.assistant.pattern;
 import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.assistant.IAstAssistant;
@@ -47,7 +48,7 @@ public class PMultipleBindAssistantTC implements IAstAssistant
 			PType type, TypeCheckInfo question)
 	{
 
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		for (PPattern p : mb.getPlist())
 		{
@@ -59,7 +60,7 @@ public class PMultipleBindAssistantTC implements IAstAssistant
 
 	public List<PMultipleBind> getMultipleBindList(PMultipleBind bind)
 	{
-		List<PMultipleBind> list = new Vector<PMultipleBind>();
+		List<PMultipleBind> list = new ArrayList<PMultipleBind>();
 		list.add(bind);
 		return list;
 	}

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/pattern/PPatternAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/pattern/PPatternAssistantTC.java
@@ -23,6 +23,7 @@ package org.overture.typechecker.assistant.pattern;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.intf.IQuestionAnswer;
@@ -63,7 +64,7 @@ public class PPatternAssistantTC extends PPatternAssistant implements IAstAssist
 	{
 		PDefinitionSet set = af.createPDefinitionSet();
 		set.addAll(af.createPPatternAssistant().getAllDefinitions(rp, ptype, scope));
-		List<PDefinition> result = new Vector<PDefinition>(set);
+		List<PDefinition> result = new ArrayList<PDefinition>(set);
 		return result;
 	}
 

--- a/core/typechecker/src/main/java/org/overture/typechecker/util/TypeCheckerUtil.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/util/TypeCheckerUtil.java
@@ -24,6 +24,7 @@ package org.overture.typechecker.util;
 import java.io.File;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.PDefinition;
@@ -120,7 +121,7 @@ public class TypeCheckerUtil
 
 		public ExpressionTypeChecker(PExp expression)
 		{
-			this(expression, new FlatEnvironment(new TypeCheckerAssistantFactory(), new Vector<PDefinition>()));// new
+			this(expression, new FlatEnvironment(new TypeCheckerAssistantFactory(), new ArrayList<PDefinition>()));// new
 																												// ModuleEnvironment(""));
 		}
 
@@ -264,7 +265,7 @@ public class TypeCheckerUtil
 			throws ParserException, LexException
 	{
 		final ITypeCheckerAssistantFactory af = new TypeCheckerAssistantFactory();
-		List<SClassDefinition> classes = new Vector<SClassDefinition>();
+		List<SClassDefinition> classes = new ArrayList<SClassDefinition>();
 		classes.addAll(parserResult.result);
 		classes.add(AstFactoryTC.newACpuClassDefinition(af));
 		classes.add(AstFactoryTC.newABusClassDefinition(af));
@@ -287,7 +288,7 @@ public class TypeCheckerUtil
 			tc.typeCheck();
 			return new TypeCheckResult<P>(parserResult, parserResult.result, TypeChecker.getWarnings(), TypeChecker.getErrors());
 		}
-		return new TypeCheckResult<P>(parserResult, null, new Vector<VDMWarning>(), new Vector<VDMError>());
+		return new TypeCheckResult<P>(parserResult, null, new ArrayList<VDMWarning>(), new ArrayList<VDMError>());
 	}
 
 }

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/DefinitionCollector.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/DefinitionCollector.java
@@ -23,6 +23,7 @@ package org.overture.typechecker.utilities;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.AnswerAdaptor;
@@ -75,7 +76,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAAssignmentDefinition(
 			AAssignmentDefinition node) throws AnalysisException
 	{
-		List<PDefinition> res = new Vector<PDefinition>();
+		List<PDefinition> res = new ArrayList<PDefinition>();
 		res.add(node);
 		return res;
 	}
@@ -84,7 +85,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> defaultSClassDefinition(SClassDefinition node)
 			throws AnalysisException
 	{
-		List<PDefinition> all = new Vector<PDefinition>();
+		List<PDefinition> all = new ArrayList<PDefinition>();
 
 		all.addAll(node.getAllInheritedDefinitions());
 		all.addAll(af.createPDefinitionListAssistant().singleDefinitions(node.getDefinitions()));
@@ -96,14 +97,14 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAClassInvariantDefinition(
 			AClassInvariantDefinition node) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseAEqualsDefinition(AEqualsDefinition node)
 			throws AnalysisException
 	{
-		return node.getDefs() == null ? new Vector<PDefinition>()
+		return node.getDefs() == null ? new ArrayList<PDefinition>()
 				: node.getDefs();
 	}
 
@@ -111,7 +112,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAExplicitFunctionDefinition(
 			AExplicitFunctionDefinition node) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 		defs.add(node);
 
 		if (node.getPredef() != null)
@@ -131,7 +132,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAExplicitOperationDefinition(
 			AExplicitOperationDefinition node) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 		defs.add(node);
 
 		if (Settings.dialect == Dialect.VDM_SL || Settings.release == Release.CLASSIC)
@@ -154,7 +155,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAExternalDefinition(AExternalDefinition node)
 			throws AnalysisException
 	{
-		List<PDefinition> result = new Vector<PDefinition>();
+		List<PDefinition> result = new ArrayList<PDefinition>();
 		result.add(node.getState());
 
 		return result;
@@ -164,7 +165,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAImplicitFunctionDefinition(
 			AImplicitFunctionDefinition node) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 		defs.add(node);
 
 		if (node.getPredef() != null)
@@ -184,7 +185,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAImplicitOperationDefinition(
 			AImplicitOperationDefinition node) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 		defs.add(node);
 
 		if (Settings.dialect == Dialect.VDM_SL || Settings.release == Release.CLASSIC)
@@ -207,7 +208,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAImportedDefinition(AImportedDefinition node)
 			throws AnalysisException
 	{
-		List<PDefinition> result = new Vector<PDefinition>();
+		List<PDefinition> result = new ArrayList<PDefinition>();
 		result.add(node.getDef());
 		return result;
 	}
@@ -223,7 +224,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAInstanceVariableDefinition(
 			AInstanceVariableDefinition node) throws AnalysisException
 	{
-		List<PDefinition> res = new Vector<PDefinition>();
+		List<PDefinition> res = new ArrayList<PDefinition>();
 		res.add(node);
 		return res;
 	}
@@ -232,7 +233,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseALocalDefinition(ALocalDefinition node)
 			throws AnalysisException
 	{
-		List<PDefinition> res = new Vector<PDefinition>();
+		List<PDefinition> res = new ArrayList<PDefinition>();
 		res.add(node);
 		return res;
 	}
@@ -241,7 +242,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAMultiBindListDefinition(
 			AMultiBindListDefinition node) throws AnalysisException
 	{
-		return node.getDefs() == null ? new Vector<PDefinition>()
+		return node.getDefs() == null ? new ArrayList<PDefinition>()
 				: node.getDefs();
 	}
 
@@ -249,14 +250,14 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAMutexSyncDefinition(AMutexSyncDefinition node)
 			throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseANamedTraceDefinition(
 			ANamedTraceDefinition node) throws AnalysisException
 	{
-		List<PDefinition> result = new Vector<PDefinition>();
+		List<PDefinition> result = new ArrayList<PDefinition>();
 		result.add(node);
 		return result;
 	}
@@ -265,7 +266,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseAPerSyncDefinition(APerSyncDefinition node)
 			throws AnalysisException
 	{
-		List<PDefinition> result = new Vector<PDefinition>();
+		List<PDefinition> result = new ArrayList<PDefinition>();
 		result.add(node);
 		return result;
 	}
@@ -274,7 +275,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseARenamedDefinition(ARenamedDefinition node)
 			throws AnalysisException
 	{
-		List<PDefinition> result = new Vector<PDefinition>();
+		List<PDefinition> result = new ArrayList<PDefinition>();
 		result.add(node);
 		return result;
 	}
@@ -291,7 +292,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 			throws AnalysisException
 	{
 
-		List<PDefinition> result = new Vector<PDefinition>();
+		List<PDefinition> result = new ArrayList<PDefinition>();
 		result.add(node.getOperationDef());
 		return result;
 	}
@@ -300,7 +301,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 	public List<PDefinition> caseATypeDefinition(ATypeDefinition node)
 			throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 		defs.add(node);
 		defs.addAll(node.getComposeDefinitions());
 
@@ -317,7 +318,7 @@ public class DefinitionCollector extends AnswerAdaptor<List<PDefinition>>
 			throws AnalysisException
 	{
 
-		List<PDefinition> result = new Vector<PDefinition>();
+		List<PDefinition> result = new ArrayList<PDefinition>();
 		result.add(node);
 		return result;
 	}

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/DefinitionTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/DefinitionTypeFinder.java
@@ -22,6 +22,7 @@
 package org.overture.typechecker.utilities;
 
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.AnswerAdaptor;
@@ -217,7 +218,7 @@ public class DefinitionTypeFinder extends AnswerAdaptor<PType>
 	public PType caseANamedTraceDefinition(ANamedTraceDefinition node)
 			throws AnalysisException
 	{
-		return AstFactory.newAOperationType(node.getLocation(), new Vector<PType>(), AstFactory.newAVoidType(node.getLocation()));
+		return AstFactory.newAOperationType(node.getLocation(), new ArrayList<PType>(), AstFactory.newAVoidType(node.getLocation()));
 	}
 
 	@Override

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/ImplicitDefinitionFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/ImplicitDefinitionFinder.java
@@ -23,6 +23,7 @@ package org.overture.typechecker.utilities;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAdaptor;
@@ -341,10 +342,10 @@ public class ImplicitDefinitionFinder extends QuestionAdaptor<Environment>
 	public AExplicitFunctionDefinition getInitDefinition(AStateDefinition d)
 	{
 		ILexLocation loc = d.getInitPattern().getLocation();
-		List<PPattern> params = new Vector<PPattern>();
+		List<PPattern> params = new ArrayList<PPattern>();
 		params.add(d.getInitPattern().clone());
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
 		parameters.add(params);
 
 		PTypeList ptypes = new PTypeList();
@@ -362,10 +363,10 @@ public class ImplicitDefinitionFinder extends QuestionAdaptor<Environment>
 	{
 
 		ILexLocation loc = d.getInvPattern().getLocation();
-		List<PPattern> params = new Vector<PPattern>();
+		List<PPattern> params = new ArrayList<PPattern>();
 		params.add(d.getInvPattern().clone());
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
 		parameters.add(params);
 
 		PTypeList ptypes = new PTypeList();
@@ -379,10 +380,10 @@ public class ImplicitDefinitionFinder extends QuestionAdaptor<Environment>
 	{
 
 		ILexLocation loc = d.getInvPattern().getLocation();
-		List<PPattern> params = new Vector<PPattern>();
+		List<PPattern> params = new ArrayList<PPattern>();
 		params.add(d.getInvPattern().clone());
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
 		parameters.add(params);
 
 		PTypeList ptypes = new PTypeList();

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/expression/ExportDefinitionFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/expression/ExportDefinitionFinder.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -77,7 +78,7 @@ public class ExportDefinitionFinder
 			AFunctionExport exp, LinkedList<PDefinition> actualDefs)
 			throws AnalysisException
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		for (ILexNameToken name : exp.getNameList())
 		{
 			PDefinition def = af.createPDefinitionListAssistant().findName(actualDefs, name, NameScope.NAMES);
@@ -155,7 +156,7 @@ public class ExportDefinitionFinder
 			AOperationExport exp, LinkedList<PDefinition> actualDefs)
 			throws AnalysisException
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		for (ILexNameToken name : ((AOperationExport) exp).getNameList())
 		{
 			PDefinition def = af.createPDefinitionListAssistant().findName(actualDefs, name, NameScope.NAMES);
@@ -186,7 +187,7 @@ public class ExportDefinitionFinder
 			LinkedList<PDefinition> actualDefs) throws AnalysisException
 	{
 		ILexNameToken name = ((ATypeExport) exp).getName();
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		PDefinition def = af.createPDefinitionListAssistant().findType(actualDefs, name, name.getModule());
 		if (def == null)
 		{
@@ -240,7 +241,7 @@ public class ExportDefinitionFinder
 	public Collection<? extends PDefinition> caseAValueExport(AValueExport exp,
 			LinkedList<PDefinition> actualDefs) throws AnalysisException
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		for (ILexNameToken name : ((AValueExport) exp).getNameList())
 		{
 			PDefinition def = af.createPDefinitionListAssistant().findName(actualDefs, name, NameScope.NAMES);

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/expression/ExportDefinitionListFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/expression/ExportDefinitionListFinder.java
@@ -25,6 +25,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.AnswerAdaptor;
@@ -66,7 +67,7 @@ public class ExportDefinitionListFinder extends
 	public Collection<? extends PDefinition> caseAFunctionExport(
 			AFunctionExport exp) throws AnalysisException
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		// AAccessSpecifierAccessSpecifier
 		for (ILexNameToken name : exp.getNameList())
 		{
@@ -82,7 +83,7 @@ public class ExportDefinitionListFinder extends
 	public Collection<? extends PDefinition> caseAOperationExport(
 			AOperationExport exp) throws AnalysisException
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		for (ILexNameToken name : exp.getNameList())
 		{
 			list.add(AstFactory.newALocalDefinition(name.getLocation(), name.clone(), NameScope.GLOBAL, exp.getExportType()));
@@ -104,7 +105,7 @@ public class ExportDefinitionListFinder extends
 	public Collection<? extends PDefinition> caseAValueExport(AValueExport exp)
 			throws AnalysisException
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		for (ILexNameToken name : exp.getNameList())
 		{
 			list.add(AstFactory.newALocalDefinition(name.getLocation(), name.clone(), NameScope.GLOBAL, exp.getExportType()));

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/expression/ImportDefinitionFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/expression/ImportDefinitionFinder.java
@@ -22,7 +22,7 @@
 package org.overture.typechecker.utilities.expression;
 
 import java.util.List;
-import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -65,7 +65,7 @@ public class ImportDefinitionFinder extends
 			TypeCheckerErrors.report(3190, "Import all from module with no exports?", imp.getLocation(), imp);
 		}
 
-		List<PDefinition> imported = new Vector<PDefinition>();
+		List<PDefinition> imported = new ArrayList<PDefinition>();
 
 		for (PDefinition d : imp.getFrom().getExportdefs())
 		{
@@ -82,7 +82,7 @@ public class ImportDefinitionFinder extends
 	public List<PDefinition> caseATypeImport(ATypeImport imp,
 			AModuleModules module) throws AnalysisException
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		imp.setFrom(module);
 
 		PDefinition expdef = af.createPDefinitionListAssistant().findType(imp.getFrom().getExportdefs(), imp.getName(), null);
@@ -111,7 +111,7 @@ public class ImportDefinitionFinder extends
 	public List<PDefinition> defaultSValueImport(SValueImport imp,
 			AModuleModules module) throws AnalysisException
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		imp.setFrom(module);
 		ILexNameToken name = imp.getName();
 

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/pattern/AllDefinitionLocator.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/pattern/AllDefinitionLocator.java
@@ -112,63 +112,63 @@ public class AllDefinitionLocator
 	public List<PDefinition> caseABooleanPattern(ABooleanPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseACharacterPattern(ACharacterPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseAExpressionPattern(AExpressionPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseAIgnorePattern(AIgnorePattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseAIntegerPattern(AIntegerPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseANilPattern(ANilPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseAQuotePattern(AQuotePattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseARealPattern(ARealPattern node,
 			NewQuestion question) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
 	public List<PDefinition> caseAStringPattern(AStringPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		return new Vector<PDefinition>();
+		return new ArrayList<PDefinition>();
 	}
 
 	@Override
@@ -185,7 +185,7 @@ public class AllDefinitionLocator
 	public List<PDefinition> caseARecordPattern(ARecordPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		PType type = pattern.getType();
 
@@ -230,7 +230,7 @@ public class AllDefinitionLocator
 	public List<PDefinition> caseASeqPattern(ASeqPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		if (!af.createPTypeAssistant().isSeq(question.ptype))
 		{
@@ -254,7 +254,7 @@ public class AllDefinitionLocator
 			NewQuestion question) throws AnalysisException
 	{
 		// return ASetPatternAssistantTC.getAllDefinitions(pattern, question.ptype, question.scope);
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		if (!af.createPTypeAssistant().isSet(question.ptype))
 		{
@@ -280,7 +280,7 @@ public class AllDefinitionLocator
 	public List<PDefinition> caseATuplePattern(ATuplePattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		if (!af.createPTypeAssistant().isProduct(question.ptype, pattern.getPlist().size()))
 		{
@@ -305,7 +305,7 @@ public class AllDefinitionLocator
 	public List<PDefinition> caseAUnionPattern(AUnionPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		if (!af.createPTypeAssistant().isSet(question.ptype))
 		{
@@ -322,7 +322,7 @@ public class AllDefinitionLocator
 	public List<PDefinition> caseAMapUnionPattern(AMapUnionPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		if (!af.createPTypeAssistant().isMap(question.ptype))
 		{
@@ -339,7 +339,7 @@ public class AllDefinitionLocator
 	public List<PDefinition> caseAMapPattern(AMapPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		if (!af.createPTypeAssistant().isMap(question.ptype))
 		{
@@ -366,7 +366,7 @@ public class AllDefinitionLocator
 	public List<PDefinition> caseAObjectPattern(AObjectPattern pattern,
 			NewQuestion question) throws AnalysisException
 	{
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 		PTypeAssistantTC typeAssistant = af.createPTypeAssistant();
 		AClassType pattype = typeAssistant.getClassType(pattern.getType(), null);
 		AClassType exptype = typeAssistant.getClassType(question.ptype, null);
@@ -422,7 +422,7 @@ public class AllDefinitionLocator
 	public Collection<? extends PDefinition> getDefinitions(
 			AMapletPatternMaplet p, SMapType map, NameScope scope) {
 
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 		list.addAll(af.createPPatternAssistant().getDefinitions(p.getFrom(),
 				map.getFrom(), scope));
 		list.addAll(af.createPPatternAssistant().getDefinitions(p.getTo(),

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/pattern/MultipleBindLister.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/pattern/MultipleBindLister.java
@@ -51,7 +51,7 @@ public class MultipleBindLister extends AnswerAdaptor<List<PMultipleBind>>
 	{
 		List<PPattern> plist = new ArrayList<PPattern>();
 		plist.add(bind.getPattern());
-		List<PMultipleBind> mblist = new Vector<PMultipleBind>();
+		List<PMultipleBind> mblist = new ArrayList<PMultipleBind>();
 		mblist.add(AstFactory.newASetMultipleBind(plist, bind.getSet()));
 		return mblist;
 	}
@@ -60,9 +60,9 @@ public class MultipleBindLister extends AnswerAdaptor<List<PMultipleBind>>
 	public List<PMultipleBind> caseATypeBind(ATypeBind bind)
 			throws AnalysisException
 	{
-		List<PPattern> plist = new Vector<PPattern>();
+		List<PPattern> plist = new ArrayList<PPattern>();
 		plist.add(bind.getPattern().clone());
-		List<PMultipleBind> mblist = new Vector<PMultipleBind>();
+		List<PMultipleBind> mblist = new ArrayList<PMultipleBind>();
 		mblist.add(AstFactory.newATypeMultipleBind(plist, bind.getType().clone()));
 		return mblist;
 	}

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ClassTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ClassTypeFinder.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.definitions.APublicAccess;
@@ -189,7 +190,7 @@ public class ClassTypeFinder extends TypeUnwrapper<AClassType>
 				}
 			}
 
-			List<PDefinition> newdefs = new Vector<PDefinition>();
+			List<PDefinition> newdefs = new ArrayList<PDefinition>();
 			PTypeAssistantTC assistant = af.createPTypeAssistant();
 
 			for (ILexNameToken synthname : common.keySet())

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ConcreateTypeImplementor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ConcreateTypeImplementor.java
@@ -23,6 +23,7 @@ package org.overture.typechecker.utilities.type;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -82,7 +83,7 @@ public class ConcreateTypeImplementor extends
 			throws AnalysisException
 	{
 		// return AFunctionTypeAssistantTC.polymorph(type, question.pname, question.actualType);
-		List<PType> polyparams = new Vector<PType>();
+		List<PType> polyparams = new ArrayList<PType>();
 
 		for (PType ptype : type.getParameters())
 		{
@@ -115,7 +116,7 @@ public class ConcreateTypeImplementor extends
 	public PType caseAProductType(AProductType type, Newquestion question)
 			throws AnalysisException
 	{
-		List<PType> polytypes = new Vector<PType>();
+		List<PType> polytypes = new ArrayList<PType>();
 
 		for (PType ptype : ((AProductType) type).getTypes())
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/FunctionTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/FunctionTypeFinder.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.AnswerAdaptor;
@@ -106,7 +107,7 @@ public class FunctionTypeFinder extends AnswerAdaptor<AFunctionType>
 
 			PTypeSet result = new PTypeSet(af);
 			Map<Integer, PTypeSet> params = new HashMap<Integer, PTypeSet>();
-			List<PDefinition> defs = new Vector<PDefinition>();
+			List<PDefinition> defs = new ArrayList<PDefinition>();
 
 			for (PType t : type.getTypes())
 			{

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/OperationTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/OperationTypeFinder.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.assistant.pattern.PTypeList;
@@ -86,7 +87,7 @@ public class OperationTypeFinder extends TypeUnwrapper<AOperationType>
 			type.setOpType(af.createPTypeAssistant().getOperation(AstFactory.newAUnknownType(type.getLocation())));
 			PTypeSet result = new PTypeSet(af);
 			Map<Integer, PTypeSet> params = new HashMap<Integer, PTypeSet>();
-			List<PDefinition> defs = new Vector<PDefinition>();
+			List<PDefinition> defs = new ArrayList<PDefinition>();
 
 			for (PType t : type.getTypes())
 			{

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/PTypeResolver.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/PTypeResolver.java
@@ -502,7 +502,7 @@ public class PTypeResolver extends
 			type.setResolved(true);
 		}
 
-		List<PType> fixed = new Vector<PType>();
+		List<PType> fixed = new ArrayList<PType>();
 		TypeCheckException problem = null;
 
 		for (PType t : type.getTypes())
@@ -641,7 +641,7 @@ public class PTypeResolver extends
 			throw problem;
 		}
 
-		type.setTypes(new Vector<PType>(fixed));
+		type.setTypes(new ArrayList<PType>(fixed));
 		
 		if (question.root != null)
 		{
@@ -721,7 +721,7 @@ public class PTypeResolver extends
 		PType r = null;
 		r = af.createPDefinitionAssistant().getType(def);
 
-		List<PDefinition> tempDefs = new Vector<PDefinition>();
+		List<PDefinition> tempDefs = new ArrayList<PDefinition>();
 		tempDefs.add(def);
 		r.setDefinitions(tempDefs);
 		return r;

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordBasisChecker.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordBasisChecker.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.factory.AstFactory;
@@ -140,7 +141,7 @@ public class RecordBasisChecker extends TypeUnwrapper<Boolean>
     			typesets.put(field, set);
     		}
 
-			List<AFieldField> fields = new Vector<AFieldField>();
+			List<AFieldField> fields = new ArrayList<AFieldField>();
 
 			for (String tag : typesets.keySet())
 			{

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordTypeFinder.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.factory.AstFactory;
@@ -138,7 +139,7 @@ public class RecordTypeFinder extends TypeUnwrapper<ARecordInvariantType>
     			typesets.put(field, set);
     		}
 
-			List<AFieldField> fields = new Vector<AFieldField>();
+			List<AFieldField> fields = new ArrayList<AFieldField>();
 
 			for (String tag : typesets.keySet())
 			{
@@ -157,7 +158,7 @@ public class RecordTypeFinder extends TypeUnwrapper<ARecordInvariantType>
 	public ARecordInvariantType caseAUnknownType(AUnknownType type)
 			throws AnalysisException
 	{
-		return AstFactory.newARecordInvariantType(type.getLocation(), new Vector<AFieldField>());
+		return AstFactory.newARecordInvariantType(type.getLocation(), new ArrayList<AFieldField>());
 	}
 
 	@Override

--- a/core/typechecker/src/main/java/org/overture/typechecker/visitor/AbstractTypeCheckVisitor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/visitor/AbstractTypeCheckVisitor.java
@@ -25,6 +25,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -250,7 +251,7 @@ public class AbstractTypeCheckVisitor extends
 
 		def.apply(THIS, question.newConstraint(null));
 		
-		List<PDefinition> qualified = new Vector<PDefinition>();
+		List<PDefinition> qualified = new ArrayList<PDefinition>();
 		
 		for (PDefinition d: question.assistantFactory.createPDefinitionAssistant().getDefinitions(def))
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/visitor/QualificationVisitor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/visitor/QualificationVisitor.java
@@ -23,6 +23,7 @@ package org.overture.typechecker.visitor;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.QuestionAnswerAdaptor;
@@ -46,7 +47,7 @@ public class QualificationVisitor extends
 	public List<QualifiedDefinition> caseAIsExp(AIsExp node,
 			TypeCheckInfo question) throws AnalysisException
 	{
-		List<QualifiedDefinition> result = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> result = new ArrayList<QualifiedDefinition>();
 
 		if (node.getTest() instanceof AVariableExp)
 		{
@@ -101,13 +102,13 @@ public class QualificationVisitor extends
 	public List<QualifiedDefinition> createNewReturnValue(INode node,
 			TypeCheckInfo question) throws AnalysisException
 	{
-		return new Vector<QualifiedDefinition>();
+		return new ArrayList<QualifiedDefinition>();
 	}
 
 	@Override
 	public List<QualifiedDefinition> createNewReturnValue(Object node,
 			TypeCheckInfo question) throws AnalysisException
 	{
-		return new Vector<QualifiedDefinition>();
+		return new ArrayList<QualifiedDefinition>();
 	}
 }

--- a/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerDefinitionVisitor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerDefinitionVisitor.java
@@ -26,6 +26,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Vector;
 import java.util.Map.Entry;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.intf.IQuestionAnswer;
@@ -164,7 +165,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 
 		if (question.assistantFactory.createPAccessSpecifierAssistant().isStatic(node.getAccess()))
 		{
-			FlatCheckedEnvironment checked = new FlatCheckedEnvironment(question.assistantFactory, new Vector<PDefinition>(), question.env, NameScope.NAMES);
+			FlatCheckedEnvironment checked = new FlatCheckedEnvironment(question.assistantFactory, new ArrayList<PDefinition>(), question.env, NameScope.NAMES);
 			checked.setStatic(true);
 			cenv = checked;
 		}
@@ -318,7 +319,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 			local.add(question.assistantFactory.createPDefinitionAssistant().getSelfDefinition(node));
 		}
 
-		List<QualifiedDefinition> qualified = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> qualified = new ArrayList<QualifiedDefinition>();
 
 		if (node.getPredef() != null)
 		{
@@ -501,14 +502,14 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 			throws AnalysisException
 	{
 		question.assistantFactory.getTypeComparator().checkComposeTypes(node.getType(), question.env, false);
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		if (node.getTypeParams() != null)
 		{
 			defs.addAll(question.assistantFactory.createAImplicitFunctionDefinitionAssistant().getTypeParamDefinitions(node));
 		}
 
-		List<PDefinition> argdefs = new Vector<PDefinition>();
+		List<PDefinition> argdefs = new ArrayList<PDefinition>();
 
 		for (APatternListTypePair pltp : node.getParamPatterns())
 		{
@@ -523,7 +524,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 
 		question.assistantFactory.createPDefinitionListAssistant().typeCheck(defs, THIS, new TypeCheckInfo(question.assistantFactory, local, question.scope, question.qualifiers));
 
-		List<QualifiedDefinition> qualified = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> qualified = new ArrayList<QualifiedDefinition>();
 
 		if (node.getPredef() != null)
 		{
@@ -765,11 +766,11 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 			}
 		}
 
-		List<QualifiedDefinition> qualified = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> qualified = new ArrayList<QualifiedDefinition>();
 
 		if (node.getPredef() != null)
 		{
-			FlatEnvironment pre = new FlatEnvironment(question.assistantFactory, new Vector<PDefinition>(), local);
+			FlatEnvironment pre = new FlatEnvironment(question.assistantFactory, new ArrayList<PDefinition>(), local);
 			pre.setEnclosingDefinition(node.getPredef());
 			pre.setFunctional(true);
 
@@ -892,8 +893,8 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 	{
 		question.assistantFactory.getTypeComparator().checkComposeTypes(node.getType(), question.env, false);
 		question = new TypeCheckInfo(question.assistantFactory, question.env, NameScope.NAMESANDSTATE, question.qualifiers);
-		List<PDefinition> defs = new Vector<PDefinition>();
-		List<PDefinition> argdefs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
+		List<PDefinition> argdefs = new ArrayList<PDefinition>();
 
 		if (question.env.isVDMPP())
 		{
@@ -1008,11 +1009,11 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 			}
 		}
 
-		List<QualifiedDefinition> qualified = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> qualified = new ArrayList<QualifiedDefinition>();
 
 		if (node.getPredef() != null)
 		{
-			FlatEnvironment pre = new FlatEnvironment(question.assistantFactory, new Vector<PDefinition>(), local);
+			FlatEnvironment pre = new FlatEnvironment(question.assistantFactory, new ArrayList<PDefinition>(), local);
 			pre.setEnclosingDefinition(node.getPredef());
 			pre.setFunctional(true);
 			PType b = node.getPredef().getBody().apply(THIS, new TypeCheckInfo(question.assistantFactory, pre, NameScope.NAMESANDSTATE));
@@ -1126,7 +1127,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 				post.unusedCheck();
 			} else
 			{
-				FlatEnvironment post = new FlatEnvironment(question.assistantFactory, new Vector<PDefinition>(), local);
+				FlatEnvironment post = new FlatEnvironment(question.assistantFactory, new ArrayList<PDefinition>(), local);
 				post.setEnclosingDefinition(node.getPostdef());
 				post.setFunctional(true);
 				b = node.getPostdef().getBody().apply(THIS, new TypeCheckInfo(question.assistantFactory, post, NameScope.NAMESANDANYSTATE));
@@ -1210,7 +1211,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 			question.assistantFactory.getTypeComparator().checkComposeTypes(node.getType(), question.env, false);
 		}
 
-		List<PDefinition> defs = new Vector<PDefinition>();
+		List<PDefinition> defs = new ArrayList<PDefinition>();
 
 		for (PMultipleBind mb : node.getBindings())
 		{
@@ -1699,7 +1700,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 	public Collection<? extends PDefinition> getDefinitions(
 			APatternListTypePair pltp, NameScope scope, ITypeCheckerAssistantFactory assistantFactory)
 	{
-		List<PDefinition> list = new Vector<PDefinition>();
+		List<PDefinition> list = new ArrayList<PDefinition>();
 
 		for (PPattern p : pltp.getPatterns())
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerExpVisitor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerExpVisitor.java
@@ -1528,7 +1528,7 @@ public class TypeCheckerExpVisitor extends AbstractTypeCheckVisitor
 						continue;
 					}
 
-					List<PType> fixed = new Vector<PType>();
+					List<PType> fixed = new ArrayList<PType>();
 
 					for (PType ptype : node.getActualTypes())
 					{
@@ -1795,11 +1795,11 @@ public class TypeCheckerExpVisitor extends AbstractTypeCheckVisitor
 	public PType caseALambdaExp(ALambdaExp node, TypeCheckInfo question)
 			throws AnalysisException
 	{
-		List<PMultipleBind> mbinds = new Vector<PMultipleBind>();
-		List<PType> ptypes = new Vector<PType>();
+		List<PMultipleBind> mbinds = new ArrayList<PMultipleBind>();
+		List<PType> ptypes = new ArrayList<PType>();
 
-		List<PPattern> paramPatterns = new Vector<PPattern>();
-		List<PDefinition> paramDefinitions = new Vector<PDefinition>();
+		List<PPattern> paramPatterns = new ArrayList<PPattern>();
+		List<PDefinition> paramDefinitions = new ArrayList<PDefinition>();
 
 		// node.setParamPatterns(paramPatterns);
 		for (ATypeBind tb : node.getBindList())
@@ -1919,8 +1919,8 @@ public class TypeCheckerExpVisitor extends AbstractTypeCheckVisitor
 	public PType caseAMapEnumMapExp(AMapEnumMapExp node, TypeCheckInfo question)
 			throws AnalysisException
 	{
-		node.setDomTypes(new Vector<PType>());
-		node.setRngTypes(new Vector<PType>());
+		node.setDomTypes(new ArrayList<PType>());
+		node.setRngTypes(new ArrayList<PType>());
 
 		if (node.getMembers().isEmpty())
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerImportsVisitor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerImportsVisitor.java
@@ -23,6 +23,7 @@ package org.overture.typechecker.visitor;
 
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.intf.IQuestionAnswer;
 import org.overture.ast.definitions.AExplicitFunctionDefinition;
@@ -127,7 +128,7 @@ public class TypeCheckerImportsVisitor extends AbstractTypeCheckVisitor
 		}
 		else
 		{
-			List<PDefinition> defs = new Vector<PDefinition>();
+			List<PDefinition> defs = new ArrayList<PDefinition>();
 
 			for (ILexNameToken pname : node.getTypeParams())
 			{

--- a/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerStmVisitor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerStmVisitor.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.Vector;
 import java.util.Map.Entry;
+import java.util.ArrayList;
 
 import org.overture.ast.analysis.AnalysisException;
 import org.overture.ast.analysis.intf.IQuestionAnswer;
@@ -1036,7 +1037,7 @@ public class TypeCheckerStmVisitor extends AbstractTypeCheckVisitor
 
 			if (boolLiteral.getValue().getValue()) // while true do...
 			{
-				List<PType> edited = new Vector<PType>();
+				List<PType> edited = new ArrayList<PType>();
 				AUnionType original = (AUnionType) stype;
 
 				for (PType t : original.getTypes())
@@ -1179,7 +1180,7 @@ public class TypeCheckerStmVisitor extends AbstractTypeCheckVisitor
 
 		// Operation must be "() ==> ()"
 
-		AOperationType expected = AstFactory.newAOperationType(node.getLocation(), new Vector<PType>(), AstFactory.newAVoidType(node.getLocation()));
+		AOperationType expected = AstFactory.newAOperationType(node.getLocation(), new ArrayList<PType>(), AstFactory.newAVoidType(node.getLocation()));
 		opdef = question.assistantFactory.createPDefinitionAssistant().deref(opdef);
 
 		if (opdef instanceof AExplicitOperationDefinition)

--- a/core/typechecker/src/test/java/org/overture/typechecker/tests/utils/OvertureTestHelper.java
+++ b/core/typechecker/src/test/java/org/overture/typechecker/tests/utils/OvertureTestHelper.java
@@ -25,6 +25,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.junit.Assert;
 import org.overture.ast.analysis.AnalysisException;
@@ -83,7 +84,7 @@ public class OvertureTestHelper
 
 	public static List<IMessage> convert(List<? extends VDMMessage> messages)
 	{
-		List<IMessage> testMessages = new Vector<IMessage>();
+		List<IMessage> testMessages = new ArrayList<IMessage>();
 
 		for (VDMMessage msg : messages)
 		{

--- a/core/typechecker/src/test/java/org/overture/typechecker/tests/utils/TestSourceFinder.java
+++ b/core/typechecker/src/test/java/org/overture/typechecker/tests/utils/TestSourceFinder.java
@@ -31,6 +31,7 @@ import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Vector;
+import java.util.ArrayList;
 
 import org.overture.ast.lex.Dialect;
 
@@ -260,7 +261,7 @@ public class TestSourceFinder
 
 	protected static List<String> readFile(File file) throws IOException
 	{
-		List<String> lines = new Vector<String>();
+		List<String> lines = new ArrayList<String>();
 		BufferedReader reader = null;
 
 		try

--- a/ide/core/src/main/java/org/overture/ide/core/ast/VdmModel.java
+++ b/ide/core/src/main/java/org/overture/ide/core/ast/VdmModel.java
@@ -74,7 +74,7 @@ public class VdmModel implements IVdmModel
 	 */
 	public synchronized List<INode> getRootElementList()
 	{
-		List<INode> list = new Vector<INode>();
+		List<INode> list = new ArrayList<INode>();
 		for (IVdmSourceUnit unit : vdmSourceUnits)
 		{
 			list.addAll(unit.getParseList());

--- a/ide/core/src/main/java/org/overture/ide/core/resources/ModelBuildPath.java
+++ b/ide/core/src/main/java/org/overture/ide/core/resources/ModelBuildPath.java
@@ -77,7 +77,7 @@ public class ModelBuildPath
 
 	public List<IContainer> getModelSrcPaths()
 	{
-		List<IContainer> tmp = new Vector<IContainer>(srcPaths.size());
+		List<IContainer> tmp = new ArrayList<IContainer>(srcPaths.size());
 		tmp.addAll(srcPaths);
 		return tmp;
 	}

--- a/ide/core/src/main/java/org/overture/ide/core/utility/FileUtility.java
+++ b/ide/core/src/main/java/org/overture/ide/core/utility/FileUtility.java
@@ -278,7 +278,7 @@ public class FileUtility
 	public static List<Character> convert(String text, String encoding)
 	{
 		InputStreamReader in = null;
-		List<Character> content = new Vector<Character>();
+		List<Character> content = new ArrayList<Character>();
 		try
 		{
 			in = new InputStreamReader(new ByteArrayInputStream(text.getBytes(encoding)), encoding);
@@ -368,7 +368,7 @@ public class FileUtility
 	{
 		InputStream inStream;
 		InputStreamReader in = null;
-		List<Character> content = new Vector<Character>();
+		List<Character> content = new ArrayList<Character>();
 		try
 		{
 			inStream = file.getContents();

--- a/ide/core/src/main/java/org/overture/ide/core/utility/LanguageManager.java
+++ b/ide/core/src/main/java/org/overture/ide/core/utility/LanguageManager.java
@@ -62,7 +62,7 @@ public class LanguageManager
 
 	private List<ILanguage> getLoadLanguages()
 	{
-		List<ILanguage> languages = new Vector<ILanguage>();
+		List<ILanguage> languages = new ArrayList<ILanguage>();
 
 		IConfigurationElement[] config = Platform.getExtensionRegistry()
 				.getConfigurationElementsFor(ICoreConstants.EXTENSION_LANGUAGE_ID);

--- a/ide/core/src/main/java/org/overture/ide/internal/core/ResourceManager.java
+++ b/ide/core/src/main/java/org/overture/ide/internal/core/ResourceManager.java
@@ -149,7 +149,7 @@ public class ResourceManager implements IResourceChangeListener
 			IResource resource, IContentType contentTypeId)
 			throws CoreException
 	{
-		List<IVdmSourceUnit> list = new Vector<IVdmSourceUnit>();
+		List<IVdmSourceUnit> list = new ArrayList<IVdmSourceUnit>();
 
 		if (resource instanceof IFolder)
 		{
@@ -438,7 +438,7 @@ public class ResourceManager implements IResourceChangeListener
 	{
 		List<IVdmSourceUnit> syncedVdmSourceUnits = project.getSpecFiles();
 
-		List<IFile> removedFiles = new Vector<IFile>();
+		List<IFile> removedFiles = new ArrayList<IFile>();
 		IProject p = (IProject) project.getAdapter(IProject.class);
 
 		for (IFile file : vdmSourceUnits.keySet())

--- a/ide/core/src/main/java/org/overture/ide/internal/core/ast/VdmModelManager.java
+++ b/ide/core/src/main/java/org/overture/ide/internal/core/ast/VdmModelManager.java
@@ -92,7 +92,7 @@ public class VdmModelManager implements IVdmModelManager
 
 	public List<IProject> getProjects()
 	{
-		List<IProject> projects = new Vector<IProject>();
+		List<IProject> projects = new ArrayList<IProject>();
 		for (IVdmProject vdmProject : asts.keySet())
 		{
 			IProject project = (IProject) vdmProject.getAdapter(IProject.class);
@@ -108,7 +108,7 @@ public class VdmModelManager implements IVdmModelManager
 
 	public List<String> getNatures(IProject project)
 	{
-		List<String> natures = new Vector<String>();
+		List<String> natures = new ArrayList<String>();
 
 		IVdmProject p = (IVdmProject) project.getAdapter(IVdmProject.class);
 		

--- a/ide/core/src/main/java/org/overture/ide/internal/core/resources/VdmProject.java
+++ b/ide/core/src/main/java/org/overture/ide/internal/core/resources/VdmProject.java
@@ -642,7 +642,7 @@ public class VdmProject implements IVdmProject
 	 */
 	public List<IVdmSourceUnit> getSpecFiles() throws CoreException
 	{
-		List<IVdmSourceUnit> list = new Vector<IVdmSourceUnit>();
+		List<IVdmSourceUnit> list = new ArrayList<IVdmSourceUnit>();
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
 		for (String contentTypeId : language.getContentTypes())
 		{
@@ -676,7 +676,7 @@ public class VdmProject implements IVdmProject
 	public List<IVdmSourceUnit> getFiles(IContentType iContentType)
 			throws CoreException
 	{
-		List<IVdmSourceUnit> list = new Vector<IVdmSourceUnit>();
+		List<IVdmSourceUnit> list = new ArrayList<IVdmSourceUnit>();
 
 		for (IContainer container : modelpath.getModelSrcPaths())
 		{
@@ -824,7 +824,7 @@ public class VdmProject implements IVdmProject
 	public List<IContentType> getContentTypeIds()
 	{
 		IContentTypeManager contentTypeManager = Platform.getContentTypeManager();
-		List<IContentType> types = new Vector<IContentType>();
+		List<IContentType> types = new ArrayList<IContentType>();
 		for (String type : language.getContentTypes())
 		{
 			types.add(contentTypeManager.getContentType(type));

--- a/ide/debug/src/main/java/org/overture/ide/debug/core/dbgp/internal/utils/DbgpXmlEntityParser.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/core/dbgp/internal/utils/DbgpXmlEntityParser.java
@@ -337,7 +337,7 @@ public class DbgpXmlEntityParser extends DbgpXmlParser
 
 	{
 
-		List<Element> elements = new Vector<Element>();
+		List<Element> elements = new ArrayList<Element>();
 
 		NodeList childs = node.getChildNodes();
 

--- a/ide/debug/src/main/java/org/overture/ide/debug/core/launching/VdmLaunchConfigurationDelegate.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/core/launching/VdmLaunchConfigurationDelegate.java
@@ -349,7 +349,7 @@ public class VdmLaunchConfigurationDelegate extends LaunchConfigurationDelegate
 	private File prepareCustomDebuggerProperties(IVdmProject project,
 			ILaunchConfiguration configuration) throws CoreException
 	{
-		List<String> properties = new Vector<String>();
+		List<String> properties = new ArrayList<String>();
 
 		String propertyCfg = configuration.getAttribute(IDebugConstants.VDM_LAUNCH_CONFIG_CUSTOM_DEBUGGER_PROPERTIES, "");
 
@@ -370,7 +370,7 @@ public class VdmLaunchConfigurationDelegate extends LaunchConfigurationDelegate
 	public static File prepareCustomOvertureProperties(IVdmProject project,
 			ILaunchConfiguration configuration) throws CoreException
 	{
-		List<String> properties = new Vector<String>();
+		List<String> properties = new ArrayList<String>();
 
 		if (VdmDebugPlugin.getDefault().getPreferenceStore().getBoolean(IDebugPreferenceConstants.PREF_DBGP_ENABLE_EXPERIMENTAL_MODELCHECKER))
 		{
@@ -427,7 +427,7 @@ public class VdmLaunchConfigurationDelegate extends LaunchConfigurationDelegate
 	private Collection<? extends String> getVmArguments(
 			ILaunchConfiguration configuration) throws CoreException
 	{
-		List<String> options = new Vector<String>();
+		List<String> options = new ArrayList<String>();
 		String opt = configuration.getAttribute(IDebugConstants.VDM_LAUNCH_CONFIG_VM_MEMORY_OPTION, "");
 		if (opt.trim().length() != 0)
 		{
@@ -490,7 +490,7 @@ public class VdmLaunchConfigurationDelegate extends LaunchConfigurationDelegate
 			IVdmProject project, ILaunchConfiguration configuration)
 			throws CoreException
 	{
-		return new Vector<String>();
+		return new ArrayList<String>();
 	}
 
 	private String getRemoteControllerName(ILaunchConfiguration configuration)
@@ -625,7 +625,7 @@ public class VdmLaunchConfigurationDelegate extends LaunchConfigurationDelegate
 
 	private List<String> getSpecFiles(IVdmProject project) throws CoreException
 	{
-		List<String> files = new Vector<String>();
+		List<String> files = new ArrayList<String>();
 
 		for (IVdmSourceUnit unit : project.getSpecFiles())
 		{

--- a/ide/debug/src/main/java/org/overture/ide/debug/logging/LogView.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/logging/LogView.java
@@ -175,7 +175,7 @@ public class LogView extends ViewPart
 			{
 				synchronized (viewer)
 				{
-					List<ViewerFilter> filters = new Vector<ViewerFilter>();
+					List<ViewerFilter> filters = new ArrayList<ViewerFilter>();
 					filters.addAll(Arrays.asList(viewer.getFilters()));
 					if (executionFilterAction.isChecked())
 					{

--- a/ide/debug/src/main/java/org/overture/ide/debug/ui/launchconfigurations/MethodSearchEngine.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/ui/launchconfigurations/MethodSearchEngine.java
@@ -62,7 +62,7 @@ public class MethodSearchEngine
 		final String RUN_NAME = "run";
 		final String WORLD_NAME = "world";
 
-		List<INode> matched = new Vector<INode>();
+		List<INode> matched = new ArrayList<INode>();
 
 		for (int i = 0; i < nodes.length; i++)
 		{

--- a/ide/debug/src/main/java/org/overture/ide/debug/ui/launching/AbstractVdmLaunchConfigurationTabGroup.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/ui/launching/AbstractVdmLaunchConfigurationTabGroup.java
@@ -34,7 +34,7 @@ public abstract class AbstractVdmLaunchConfigurationTabGroup extends
 {
 	public void createTabs(ILaunchConfigurationDialog dialog, String mode)
 	{
-		List<ILaunchConfigurationTab> tabs = new Vector<ILaunchConfigurationTab>();
+		List<ILaunchConfigurationTab> tabs = new ArrayList<ILaunchConfigurationTab>();
 		tabs.add(getMainTab());
 		tabs.add(getRuntimeTab());
 		tabs.add(new VmArgumentsLaunchConfigurationTab());
@@ -66,7 +66,7 @@ public abstract class AbstractVdmLaunchConfigurationTabGroup extends
 	 */
 	protected List<ILaunchConfigurationTab> getAdditionalTabs()
 	{
-		return new Vector<ILaunchConfigurationTab>();
+		return new ArrayList<ILaunchConfigurationTab>();
 	}
 
 }

--- a/ide/debug/src/main/java/org/overture/ide/debug/ui/launching/AbstractVdmMainLaunchConfigurationTab.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/ui/launching/AbstractVdmMainLaunchConfigurationTab.java
@@ -428,7 +428,7 @@ public abstract class AbstractVdmMainLaunchConfigurationTab extends
 					@Override
 					public Object[] getElements(Object element)
 					{
-						List<IProject> elements = new Vector<IProject>();
+						List<IProject> elements = new ArrayList<IProject>();
 						Object[] arr = super.getElements(element);
 						if (arr != null)
 						{

--- a/ide/debug/src/main/java/org/overture/ide/debug/ui/log/VdmDebugLogView.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/ui/log/VdmDebugLogView.java
@@ -263,7 +263,7 @@ public class VdmDebugLogView extends ViewPart
 			{
 				synchronized (viewer)
 				{
-					List<ViewerFilter> filters = new Vector<ViewerFilter>();
+					List<ViewerFilter> filters = new ArrayList<ViewerFilter>();
 					filters.addAll(Arrays.asList(viewer.getFilters()));
 					if (executionFilterAction.isChecked())
 					{

--- a/ide/debug/src/main/java/org/overture/ide/debug/utils/JarClassSelector.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/utils/JarClassSelector.java
@@ -79,7 +79,7 @@ public class JarClassSelector
 			});
 		}
 
-		List<String> classes = new Vector<String>();
+		List<String> classes = new ArrayList<String>();
 		for (String path : jars)
 		{
 			classes.addAll(PackageUtils.getClasseNamesInPackage(path, null));

--- a/ide/debug/src/main/java/org/overture/ide/debug/utils/VdmProjectClassPathCollector.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/utils/VdmProjectClassPathCollector.java
@@ -47,7 +47,7 @@ public class VdmProjectClassPathCollector extends ClassPathCollector
 	public static List<String> getClassPath(IProject project,
 			String[] bundleIds, String... additionalCpEntries)
 	{
-		List<String> entries = new Vector<String>();
+		List<String> entries = new ArrayList<String>();
 		// get the class path for all jars in the project lib folder
 		File lib = new File(project.getLocation().toFile(), "lib");
 		if (lib.exists() && lib.isDirectory())
@@ -71,7 +71,7 @@ public class VdmProjectClassPathCollector extends ClassPathCollector
 
 	private static List<File> getAllDirectories(File file)
 	{
-		List<File> files = new Vector<File>();
+		List<File> files = new ArrayList<File>();
 		if (file.isDirectory())
 		{
 			files.add(file);
@@ -86,7 +86,7 @@ public class VdmProjectClassPathCollector extends ClassPathCollector
 
 	private static List<File> getAllFiles(File file, Set<String> extensionFilter)
 	{
-		List<File> files = new Vector<File>();
+		List<File> files = new ArrayList<File>();
 		if (file.isDirectory())
 		{
 			for (File f : file.listFiles())

--- a/ide/debug/src/main/java/org/overture/ide/debug/utils/ui/DebuggerPropertiesManager.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/utils/ui/DebuggerPropertiesManager.java
@@ -77,7 +77,7 @@ public class DebuggerPropertiesManager
 		rowLayout.spacing = 0;
 		group.setLayout(rowLayout);
 
-		List<DebuggerProperty> sorted = new Vector<DebuggerProperty>();
+		List<DebuggerProperty> sorted = new ArrayList<DebuggerProperty>();
 		sorted.addAll(props);
 		Collections.sort(sorted);
 
@@ -180,7 +180,7 @@ public class DebuggerPropertiesManager
 		// configuration.setAttribute(launchConfigkey, getConfigString(props));
 		try
 		{
-			List<DebuggerProperty> sorted = new Vector<DebuggerProperty>();
+			List<DebuggerProperty> sorted = new ArrayList<DebuggerProperty>();
 			sorted.addAll(props);
 			Collections.sort(sorted);
 
@@ -214,7 +214,7 @@ public class DebuggerPropertiesManager
 	public void setDefaults(Set<DebuggerProperty> defaultProps,
 			ILaunchConfigurationWorkingCopy configuration)
 	{
-		List<DebuggerProperty> dProps = new Vector<DebuggerProperty>(defaultProps);
+		List<DebuggerProperty> dProps = new ArrayList<DebuggerProperty>(defaultProps);
 		Collections.sort(dProps);
 		initializeFrom(getConfigString(dProps));
 		performApply(configuration);

--- a/ide/debug/src/main/java/org/overture/ide/debug/utils/xml/XMLParser.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/utils/xml/XMLParser.java
@@ -297,7 +297,7 @@ public class XMLParser
 		checkFor(Token.TAG);
 
 		Properties attr = null;
-		List<XMLNode> children = new Vector<XMLNode>();
+		List<XMLNode> children = new ArrayList<XMLNode>();
 
 		if (token == Token.TAG)
 		{

--- a/ide/parsers/vdmj/src/main/java/org/overture/ide/parsers/vdmj/SourceParserVdmPp.java
+++ b/ide/parsers/vdmj/src/main/java/org/overture/ide/parsers/vdmj/SourceParserVdmPp.java
@@ -83,7 +83,7 @@ public class SourceParserVdmPp extends AbstractParserParticipant
 			LexTokenReader ltr = new LexTokenReader(source, Settings.dialect, file.getSystemFile(), charset, streamReaderType);
 			reader = new ClassReader(ltr);
 			classes.addAll(reader.readClasses());
-			List<INode> nodes = new Vector<INode>();
+			List<INode> nodes = new ArrayList<INode>();
 			for (SClassDefinition classDefinition : classes)
 			{
 				nodes.add(classDefinition);

--- a/ide/parsers/vdmj/src/main/java/org/overture/ide/parsers/vdmj/SourceParserVdmSl.java
+++ b/ide/parsers/vdmj/src/main/java/org/overture/ide/parsers/vdmj/SourceParserVdmSl.java
@@ -76,7 +76,7 @@ public class SourceParserVdmSl extends AbstractParserParticipant
 			reader = new ModuleReader(ltr);
 			modules.addAll(reader.readModules());
 
-			List<INode> nodes = new Vector<INode>();
+			List<INode> nodes = new ArrayList<INode>();
 			for (AModuleModules module : modules)
 			{
 				nodes.add(module);

--- a/ide/plugins/combinatorialtesting/src/main/java/org/overture/combinatorialtesting/vdmj/server/xml/XMLParser.java
+++ b/ide/plugins/combinatorialtesting/src/main/java/org/overture/combinatorialtesting/vdmj/server/xml/XMLParser.java
@@ -300,7 +300,7 @@ public class XMLParser
 		checkFor(Token.TAG);
 
 		Properties attr = null;
-		List<XMLNode> children = new Vector<XMLNode>();
+		List<XMLNode> children = new ArrayList<XMLNode>();
 
 		if (token == Token.TAG)
 		{

--- a/ide/plugins/combinatorialtesting/src/main/java/org/overture/ide/plugins/combinatorialtesting/TracesXmlStoreReader.java
+++ b/ide/plugins/combinatorialtesting/src/main/java/org/overture/ide/plugins/combinatorialtesting/TracesXmlStoreReader.java
@@ -239,7 +239,7 @@ public class TracesXmlStoreReader extends DefaultHandler
 			Integer startNumber, Integer stopNumber) throws SAXException,
 			IOException
 	{
-		traceTestResults = new Vector<TraceTestResult>();
+		traceTestResults = new ArrayList<TraceTestResult>();
 
 		this.traceTaceTestStartNumber = startNumber;
 		this.traceTaceTestStopNumber = stopNumber;
@@ -395,7 +395,7 @@ public class TracesXmlStoreReader extends DefaultHandler
 		{
 			if (insertArgument)
 			{
-				List<String> arguments = new Vector<String>();
+				List<String> arguments = new ArrayList<String>();
 				for (String string : XmlFileWriter.deNormalizeValue(data.toString()).trim().split(";"))
 				{
 					arguments.add(string.trim());
@@ -404,7 +404,7 @@ public class TracesXmlStoreReader extends DefaultHandler
 
 			} else if (insertResult)
 			{
-				List<String> results = new Vector<String>();
+				List<String> results = new ArrayList<String>();
 				for (String string : XmlFileWriter.deNormalizeValue(data.toString()).trim().split(";"))
 				{
 					results.add(string.trim());

--- a/ide/plugins/combinatorialtesting/src/main/java/org/overture/ide/plugins/combinatorialtesting/internal/TestEngineDelegate.java
+++ b/ide/plugins/combinatorialtesting/src/main/java/org/overture/ide/plugins/combinatorialtesting/internal/TestEngineDelegate.java
@@ -208,7 +208,7 @@ public class TestEngineDelegate
 	private Collection<? extends String> getVmArguments(
 			IPreferenceStore preferences)
 	{
-		List<String> options = new Vector<String>();
+		List<String> options = new ArrayList<String>();
 		String opt = preferences.getString(IDebugConstants.VDM_LAUNCH_CONFIG_VM_MEMORY_OPTION);
 		if (opt.trim().length() != 0)
 		{
@@ -246,7 +246,7 @@ public class TestEngineDelegate
 
 	private List<String> getSpecFiles(IVdmProject project) throws CoreException
 	{
-		List<String> files = new Vector<String>();
+		List<String> files = new ArrayList<String>();
 
 		for (IVdmSourceUnit unit : project.getSpecFiles())
 		{

--- a/ide/plugins/combinatorialtesting/src/main/java/org/overture/ide/plugins/combinatorialtesting/internal/VdmjTracesHelper.java
+++ b/ide/plugins/combinatorialtesting/src/main/java/org/overture/ide/plugins/combinatorialtesting/internal/VdmjTracesHelper.java
@@ -162,7 +162,7 @@ public class VdmjTracesHelper
 			IProgressMonitor monitor, ITracesDisplay display,
 			boolean useReduction) throws IOException, CoreException
 	{
-		List<TraceExecutionSetup> traceSetups = new Vector<TraceExecutionSetup>();
+		List<TraceExecutionSetup> traceSetups = new ArrayList<TraceExecutionSetup>();
 
 		if (container != null)
 		{

--- a/ide/plugins/combinatorialtesting/src/main/java/org/overture/ide/plugins/combinatorialtesting/views/ViewContentProvider.java
+++ b/ide/plugins/combinatorialtesting/src/main/java/org/overture/ide/plugins/combinatorialtesting/views/ViewContentProvider.java
@@ -117,7 +117,7 @@ public class ViewContentProvider implements IStructuredContentProvider,
 		if (parent instanceof SClassDefinition
 				|| parent instanceof AModuleModules)
 		{
-			List<TraceTreeNode> children = new Vector<TraceTreeNode>();
+			List<TraceTreeNode> children = new ArrayList<TraceTreeNode>();
 
 			List<ANamedTraceDefinition> traceDefs = TraceAstUtility.getTraceDefinitions((INode) parent);
 			if (containerNodes.containsKey(parent)
@@ -289,7 +289,7 @@ public class ViewContentProvider implements IStructuredContentProvider,
 
 	static class TraceSearch extends AnalysisAdaptor
 	{
-		List<ANamedTraceDefinition> containers = new Vector<ANamedTraceDefinition>();
+		List<ANamedTraceDefinition> containers = new ArrayList<ANamedTraceDefinition>();
 
 		public List<ANamedTraceDefinition> getTraces(INode node)
 		{

--- a/ide/plugins/csk/src/main/java/org/overture/ide/plugins/csk/handlers/OpenVdmToolsProjectCommandHandler.java
+++ b/ide/plugins/csk/src/main/java/org/overture/ide/plugins/csk/handlers/OpenVdmToolsProjectCommandHandler.java
@@ -58,7 +58,7 @@ public class OpenVdmToolsProjectCommandHandler extends AbstractHandler
 		
 		if (vdmProject != null)
 		{
-			final List<File> files = new Vector<File>();
+			final List<File> files = new ArrayList<File>();
 
 			try
 			{

--- a/ide/plugins/latex/src/main/java/org/overture/ide/plugins/latex/utility/LatexUtilsBase.java
+++ b/ide/plugins/latex/src/main/java/org/overture/ide/plugins/latex/utility/LatexUtilsBase.java
@@ -76,7 +76,7 @@ public class LatexUtilsBase
 
 	static List<File> getFileChildern(File file)
 	{
-		List<File> list = new Vector<File>();
+		List<File> list = new ArrayList<File>();
 
 		if (file.isFile())
 		{

--- a/ide/plugins/rttraceviewer/src/main/java/org/overture/ide/plugins/rttraceviewer/draw/ArchitectureViewer.java
+++ b/ide/plugins/rttraceviewer/src/main/java/org/overture/ide/plugins/rttraceviewer/draw/ArchitectureViewer.java
@@ -79,7 +79,7 @@ public class ArchitectureViewer extends TraceViewer {
 			
 			tab.addFigure(rectFigure);
 
-			vLines.put(cpu.getId(), new Vector<Line>());
+			vLines.put(cpu.getId(), new ArrayList<Line>());
 			cpuCoordinates.put(cpu.getId(), rectPoint);
 		}
 	}

--- a/ide/plugins/uml2/src/main/java/org/overture/ide/plugins/uml2/uml2vdm/Uml2Vdm.java
+++ b/ide/plugins/uml2/src/main/java/org/overture/ide/plugins/uml2/uml2vdm/Uml2Vdm.java
@@ -278,10 +278,10 @@ public class Uml2Vdm
 		console.out.println("\tConverting function: " + op.getName());
 		LexNameToken name = new LexNameToken(c.getName().getName(), op.getName(), null);
 
-		List<List<PPattern>> paramPatternList = new Vector<List<PPattern>>();
-		List<PPattern> paramPatterns = new Vector<PPattern>();
+		List<List<PPattern>> paramPatternList = new ArrayList<List<PPattern>>();
+		List<PPattern> paramPatterns = new ArrayList<PPattern>();
 		paramPatternList.add(paramPatterns);
-		List<PType> parameterTypes = new Vector<PType>();
+		List<PType> parameterTypes = new ArrayList<PType>();
 
 		for (Parameter p : op.getOwnedParameters())
 		{
@@ -304,8 +304,8 @@ public class Uml2Vdm
 	{
 		console.out.println("\tConverting operation: " + op.getName());
 		LexNameToken name = new LexNameToken(c.getName().getName(), op.getName(), null);
-		List<PType> parameterTypes = new Vector<PType>();
-		List<PPattern> parameters = new Vector<PPattern>();
+		List<PType> parameterTypes = new ArrayList<PType>();
+		List<PPattern> parameters = new ArrayList<PPattern>();
 		for (Parameter p : op.getOwnedParameters())
 		{
 			if (p.getName() == null)

--- a/ide/plugins/uml2/src/main/java/org/overture/ide/plugins/uml2/uml2vdm/VdmTypeCreator.java
+++ b/ide/plugins/uml2/src/main/java/org/overture/ide/plugins/uml2/uml2vdm/VdmTypeCreator.java
@@ -303,7 +303,7 @@ public class VdmTypeCreator
 	public PType createRecord(Class innerType)
 	{
 
-		List<AFieldField> fields = new Vector<AFieldField>();
+		List<AFieldField> fields = new ArrayList<AFieldField>();
 
 		for (Property p : innerType.getOwnedAttributes())
 		{

--- a/ide/plugins/uml2/src/main/java/org/overture/ide/plugins/uml2/vdm2uml/UmlDeploymentCreator.java
+++ b/ide/plugins/uml2/src/main/java/org/overture/ide/plugins/uml2/vdm2uml/UmlDeploymentCreator.java
@@ -77,7 +77,7 @@ public class UmlDeploymentCreator
 	public void buildDeployment(List<SClassDefinition> classes2)
 	{
 		Map<String, Node> nodes = new HashMap<String, Node>();
-		List<AInstanceVariableDefinition> systemInsts = new Vector<AInstanceVariableDefinition>();
+		List<AInstanceVariableDefinition> systemInsts = new ArrayList<AInstanceVariableDefinition>();
 		ASystemClassDefinition system = null;
 		Package deploymentPackage = null;
 		for (SClassDefinition c : classes2)

--- a/ide/plugins/uml2/src/main/java/org/overture/ide/plugins/uml2/vdm2uml/Vdm2Uml.java
+++ b/ide/plugins/uml2/src/main/java/org/overture/ide/plugins/uml2/vdm2uml/Vdm2Uml.java
@@ -178,7 +178,7 @@ public class Vdm2Uml
 
 		utc.setModelWorkingCopy(modelWorkingCopy);
 
-		List<SClassDefinition> onlyClasses = new Vector<SClassDefinition>();
+		List<SClassDefinition> onlyClasses = new ArrayList<SClassDefinition>();
 		onlyClasses.addAll(classes);
 		for (SClassDefinition sClassDefinition : classes)
 		{
@@ -210,7 +210,7 @@ public class Vdm2Uml
 			BufferedReader br = new BufferedReader(fr);
 
 			String line = null;
-			List<String> buffer = new Vector<String>();
+			List<String> buffer = new ArrayList<String>();
 			while ((line = br.readLine()) != null)
 			{
 				line = line.replace("\"http://www.eclipse.org/uml2/4.0.0/UML\"", "\"http://www.eclipse.org/uml2/3.0.0/UML\"");

--- a/ide/ui/src/main/java/org/overture/ide/ui/adapters/AdapterFactoryWorkbenchAdapter.java
+++ b/ide/ui/src/main/java/org/overture/ide/ui/adapters/AdapterFactoryWorkbenchAdapter.java
@@ -246,7 +246,7 @@ public class AdapterFactoryWorkbenchAdapter implements IAdapterFactory
 
 	private static List<IOvertureWorkbenchAdapter> getOvertureWorkbenchAdapterExtensions()
 	{
-		List<IOvertureWorkbenchAdapter> extensions = new Vector<IOvertureWorkbenchAdapter>();
+		List<IOvertureWorkbenchAdapter> extensions = new ArrayList<IOvertureWorkbenchAdapter>();
 		try
 		{
 			IConfigurationElement[] config = Platform.getExtensionRegistry().getConfigurationElementsFor(IVdmUiConstants.EXTENSION_WORKBENCH_DISPLAY);

--- a/ide/ui/src/main/java/org/overture/ide/ui/property/VdmBuildPathPropertyPage.java
+++ b/ide/ui/src/main/java/org/overture/ide/ui/property/VdmBuildPathPropertyPage.java
@@ -168,7 +168,7 @@ public class VdmBuildPathPropertyPage extends PropertyPage implements
 					@Override
 					public Object[] getElements(Object element)
 					{
-						List<IFolder> elements = new Vector<IFolder>();
+						List<IFolder> elements = new ArrayList<IFolder>();
 						Object[] arr = super.getElements(element);
 						if (arr != null)
 						{
@@ -188,7 +188,7 @@ public class VdmBuildPathPropertyPage extends PropertyPage implements
 					@Override
 					public Object[] getChildren(Object element)
 					{
-						List<IFolder> elements = new Vector<IFolder>();
+						List<IFolder> elements = new ArrayList<IFolder>();
 						Object[] arr = super.getChildren(element);
 						if (arr != null)
 						{

--- a/ide/ui/src/main/java/org/overture/ide/ui/templates/VdmCompleteProcessor.java
+++ b/ide/ui/src/main/java/org/overture/ide/ui/templates/VdmCompleteProcessor.java
@@ -65,7 +65,7 @@ public class VdmCompleteProcessor
 			VdmDocument document, List<ICompletionProposal> proposals,
 			int offset)
 	{
-		List<ICompletionProposal> calculatedProposals = new Vector<ICompletionProposal>();
+		List<ICompletionProposal> calculatedProposals = new ArrayList<ICompletionProposal>();
 
 		switch (info.getType())
 		{
@@ -90,7 +90,7 @@ public class VdmCompleteProcessor
 
 		}
 
-		List<String> replacementDisplayString = new Vector<String>();
+		List<String> replacementDisplayString = new ArrayList<String>();
 		for (ICompletionProposal proposal : calculatedProposals)
 		{
 			if (proposal instanceof CompletionProposal)
@@ -449,7 +449,7 @@ public class VdmCompleteProcessor
 
 	private List<INode> getAst(VdmDocument document)
 	{
-		List<INode> ast = new Vector<INode>();
+		List<INode> ast = new ArrayList<INode>();
 		ast.addAll(document.getProject().getModel().getRootElementList());
 		ast.addAll(document.getSourceUnit().getParseList());// maybe add broken parse tree
 		return ast;
@@ -457,7 +457,7 @@ public class VdmCompleteProcessor
 
 	private List<INode> getLocalFileAst(VdmDocument document)
 	{
-		List<INode> ast = new Vector<INode>();
+		List<INode> ast = new ArrayList<INode>();
 		ast.addAll(document.getSourceUnit().getParseList());
 		return ast;
 	}

--- a/ide/ui/src/main/java/org/overture/ide/ui/wizard/pages/WizardProjectsImportPageProxy.java
+++ b/ide/ui/src/main/java/org/overture/ide/ui/wizard/pages/WizardProjectsImportPageProxy.java
@@ -190,7 +190,7 @@ public class WizardProjectsImportPageProxy {
 			m = mainPage.getClass().getDeclaredMethod(method);
 			args = null;
 		} else {
-			List<Class<?>> parameterTypes = new Vector<Class<?>>();
+			List<Class<?>> parameterTypes = new ArrayList<Class<?>>();
 			for (Object object : args) {
 				if(object instanceof Boolean)
 				{

--- a/ide/vdmrt/ui/src/main/java/org/overture/ide/vdmrt/ui/handlers/ConvertVdmPpToVdmRtCommandHandler.java
+++ b/ide/vdmrt/ui/src/main/java/org/overture/ide/vdmrt/ui/handlers/ConvertVdmPpToVdmRtCommandHandler.java
@@ -78,7 +78,7 @@ public class ConvertVdmPpToVdmRtCommandHandler extends AbstractHandler
 								IProjectDescription description = new ProjectDescription();
 								description.setName(project.getName() + "_VDM_RT");
 								description.setBuildSpec(project.getDescription().getBuildSpec());
-								List<String> natures = new Vector<String>();
+								List<String> natures = new ArrayList<String>();
 								natures.addAll(Arrays.asList(project.getDescription().getNatureIds()));
 
 								if (natures.contains(IVdmPpCoreConstants.NATURE))

--- a/tools/packworkspace/src/main/java/org/overture/tools/packworkspace/Controller.java
+++ b/tools/packworkspace/src/main/java/org/overture/tools/packworkspace/Controller.java
@@ -267,7 +267,7 @@ public class Controller
 
 	public List<RssItem> getRssItems()
 	{
-		List<RssItem> items = new Vector<RssItem>();
+		List<RssItem> items = new ArrayList<RssItem>();
 
 		for (ProjectPacker p : projects)
 		{

--- a/tools/packworkspace/src/main/java/org/overture/tools/packworkspace/Main.java
+++ b/tools/packworkspace/src/main/java/org/overture/tools/packworkspace/Main.java
@@ -85,12 +85,12 @@ public class Main
 			else
 				return;
 		}
-		List<Controller> controllers = new Vector<Controller>();
+		List<Controller> controllers = new ArrayList<Controller>();
 
 		Controller controller = runController(dialect, inputRootFolder, tmpFolder);
 		controllers.add(controller);
 
-		List<RssItem> items = new Vector<RssItem>();
+		List<RssItem> items = new ArrayList<RssItem>();
 		for (Controller c : controllers)
 		{
 			items.addAll(c.getRssItems());
@@ -134,7 +134,7 @@ static	List<File> zipFiles = new Vector<File>();
 
 		File tmpFolder = new File("tmp");
 
-		List<Controller> controllers = new Vector<Controller>();
+		List<Controller> controllers = new ArrayList<Controller>();
 
 		Controller controller = runController(Dialect.VDM_SL, new File(root, "VDMSL"), tmpFolder);
 		controllers.add(controller);
@@ -147,7 +147,7 @@ static	List<File> zipFiles = new Vector<File>();
 		controller = runController(Dialect.VDM_RT, new File(root, "VDMRT"), tmpFolder);
 		controllers.add(controller);
 
-		List<RssItem> items = new Vector<RssItem>();
+		List<RssItem> items = new ArrayList<RssItem>();
 		for (Controller c : controllers)
 		{
 			c.createWebSite();

--- a/tools/packworkspace/src/main/java/org/overture/tools/packworkspace/ProjectPacker.java
+++ b/tools/packworkspace/src/main/java/org/overture/tools/packworkspace/ProjectPacker.java
@@ -152,7 +152,7 @@ public class ProjectPacker implements Comparable<ProjectPacker>
 
 	public List<File> getSpecFiles(File root)
 	{
-		List<File> specFiles = new Vector<File>();
+		List<File> specFiles = new ArrayList<File>();
 		for (File f : root.listFiles())
 		{
 			if (f.isFile() && f.getName().toLowerCase().endsWith(".vdmpp")

--- a/tools/packworkspace/src/main/java/org/overture/tools/packworkspace/testing/ProjectTester.java
+++ b/tools/packworkspace/src/main/java/org/overture/tools/packworkspace/testing/ProjectTester.java
@@ -374,7 +374,7 @@ public class ProjectTester
 			throws IOException, InterruptedException
 	{
 
-		List<String> command = new Vector<String>();
+		List<String> command = new ArrayList<String>();
 		command.add("java");
 		for (String argument : project.getSettings().getVmArguments())
 		{


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
Ayman Abdelghany.
