### PR TITLE
Use Java collection interfaces rather than specific implementation

### DIFF
--- a/core/ast/src/main/java/org/overture/ast/util/modules/CombinedDefaultModule.java
+++ b/core/ast/src/main/java/org/overture/ast/util/modules/CombinedDefaultModule.java
@@ -79,7 +79,7 @@ public class CombinedDefaultModule extends AModuleModules
 	@Override
 	public List<? extends ClonableFile> getFiles()
 	{
-		LinkedList<ClonableFile> allFiles = new LinkedList<ClonableFile>();
+		List<ClonableFile> allFiles = new LinkedList<ClonableFile>();
 
 		for (AModuleModules m : modules)
 		{

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCallStmToStringBuilder.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCallStmToStringBuilder.java
@@ -39,7 +39,7 @@ public class JavaCallStmToStringBuilder extends JavaClassCreatorBase implements 
 
 			STypeIR type = plainCall.getClassType();
 			String name = plainCall.getName();
-			LinkedList<SExpIR> args = plainCall.getArgs();
+			List<SExpIR> args = plainCall.getArgs();
 
 			String prefix = "";
 
@@ -58,7 +58,7 @@ public class JavaCallStmToStringBuilder extends JavaClassCreatorBase implements 
 
 			SExpIR obj = callObj.getObj();
 			String field = callObj.getFieldName();
-			LinkedList<SExpIR> args = callObj.getArgs();
+			List<SExpIR> args = callObj.getArgs();
 
 			String prefix = obj.toString();
 			prefix += "." + field;

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaClassCreator.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaClassCreator.java
@@ -1,6 +1,7 @@
 package org.overture.codegen.vdm2java;
 
 import java.util.LinkedList;
+import java.util.List;
 
 import org.overture.codegen.ir.SExpIR;
 import org.overture.codegen.ir.declarations.ADefaultClassDeclIR;
@@ -29,7 +30,7 @@ public class JavaClassCreator extends JavaClassCreatorBase
 		
 		AMethodDeclIR toStringMethod = consToStringSignature();
 		
-		LinkedList<AFieldDeclIR> fields = classDecl.getFields();
+		List<AFieldDeclIR> fields = classDecl.getFields();
 
 		AReturnStmIR body = new AReturnStmIR();
 		

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaFormat.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaFormat.java
@@ -208,7 +208,7 @@ public class JavaFormat
 		AInterfaceTypeIR methodClass = new AInterfaceTypeIR();
 		methodClass.setName(methodTypeInterface.getName());
 
-		LinkedList<STypeIR> params = methodType.getParams();
+		List<STypeIR> params = methodType.getParams();
 
 		for (STypeIR param : params)
 		{
@@ -606,7 +606,7 @@ public class JavaFormat
 	
 	public String formatInterfaces(SClassDeclIR classDecl)
 	{
-		LinkedList<AInterfaceDeclIR> interfaces = classDecl.getInterfaces();
+		List<AInterfaceDeclIR> interfaces = classDecl.getInterfaces();
 		
 		if(interfaces == null)
 		{

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaFormatAssistant.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaFormatAssistant.java
@@ -22,6 +22,7 @@
 package org.overture.codegen.vdm2java;
 
 import java.util.LinkedList;
+import java.util.List;
 
 import org.overture.codegen.ir.SExpIR;
 import org.overture.codegen.ir.STypeIR;
@@ -220,10 +221,10 @@ public class JavaFormatAssistant extends JavaClassCreatorBase
 	public AApplyExpIR consUtilCallUsingRecFields(ARecordDeclIR record,
 			STypeIR returnType, String memberName)
 	{
-		LinkedList<AFieldDeclIR> fields = record.getFields();
+		List<AFieldDeclIR> fields = record.getFields();
 
 		AApplyExpIR call = consUtilCall(returnType, memberName);
-		LinkedList<SExpIR> args = call.getArgs();
+		List<SExpIR> args = call.getArgs();
 
 		for (AFieldDeclIR field : fields)
 		{

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaRecordCreator.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaRecordCreator.java
@@ -74,9 +74,9 @@ public class JavaRecordCreator extends JavaClassCreatorBase
 		ABlockStmIR body = new ABlockStmIR();
 		constructor.setBody(body);
 
-		LinkedList<AFormalParamLocalParamIR> formalParams = constructor.getFormalParams();
-		LinkedList<SStmIR> bodyStms = body.getStatements();
-		LinkedList<AFieldDeclIR> fields = record.getFields();
+		List<AFormalParamLocalParamIR> formalParams = constructor.getFormalParams();
+		List<SStmIR> bodyStms = body.getStatements();
+		List<AFieldDeclIR> fields = record.getFields();
 		
 		for (AFieldDeclIR field : fields)
 		{
@@ -186,7 +186,7 @@ public class JavaRecordCreator extends JavaClassCreatorBase
 		AMethodDeclIR equalsMethod = consEqualMethodSignature(paramName);
 
 		ABlockStmIR equalsMethodBody = new ABlockStmIR();
-		LinkedList<SStmIR> equalsStms = equalsMethodBody.getStatements();
+		List<SStmIR> equalsStms = equalsMethodBody.getStatements();
 		
 		AReturnStmIR returnTypeComp = new AReturnStmIR();
 		if (record.getFields().isEmpty())
@@ -218,7 +218,7 @@ public class JavaRecordCreator extends JavaClassCreatorBase
 
 			// Next compare the fields of the instance with the fields of the formal parameter "obj":
 			// return (field1 == obj.field1) && (field2 == other.field2)...
-			LinkedList<AFieldDeclIR> fields = record.getFields();
+			List<AFieldDeclIR> fields = record.getFields();
 			SExpIR previousComparisons = javaFormat.getJavaFormatAssistant().consFieldComparison(record, fields.get(0), localVarName);
 
 			for (int i = 1; i < fields.size(); i++)

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaValueSemantics.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaValueSemantics.java
@@ -331,7 +331,7 @@ public class JavaValueSemantics
 		
 		if(encClass != null)
 		{
-			LinkedList<AMethodDeclIR> methods = encClass.getMethods();
+			List<AMethodDeclIR> methods = encClass.getMethods();
 			
 			boolean isRec = false;
 			for(AMethodDeclIR m : methods)
@@ -504,7 +504,7 @@ public class JavaValueSemantics
 	{
 		if(type instanceof AUnionTypeIR)
 		{
-			LinkedList<STypeIR> types = ((AUnionTypeIR) type).getTypes();
+			List<STypeIR> types = ((AUnionTypeIR) type).getTypes();
 			
 			for(STypeIR t : types)
 			{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/IdStateDesignatorDefCollector.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/IdStateDesignatorDefCollector.java
@@ -121,7 +121,7 @@ public class IdStateDesignatorDefCollector extends VdmAnalysis
 
 	private void loadClassGlobals(SClassDefinition node)
 	{
-		LinkedList<PDefinition> allDefs = new LinkedList<PDefinition>(node.getAllInheritedDefinitions());
+		List<PDefinition> allDefs = new LinkedList<PDefinition>(node.getAllInheritedDefinitions());
 		allDefs.addAll(node.getDefinitions());
 		
 		// Instance variables and values are visible to all operations

--- a/core/codegen/platform/src/main/java/org/overture/codegen/assistant/DeclAssistantIR.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/assistant/DeclAssistantIR.java
@@ -136,7 +136,7 @@ public class DeclAssistantIR extends AssistantBase
 		String access = node.getAccess().getAccess().toString();
 		boolean isAbstract = node.getIsAbstract();
 		boolean isStatic = false;
-		LinkedList<ILexNameToken> superNames = node.getSupernames();
+		List<ILexNameToken> superNames = node.getSupernames();
 
 		classCg.setPackage(null);
 		classCg.setName(name);
@@ -153,7 +153,7 @@ public class DeclAssistantIR extends AssistantBase
 			classCg.getSuperNames().add(superName);
 		}
 
-		LinkedList<PDefinition> defs = node.getDefinitions();
+		List<PDefinition> defs = node.getDefinitions();
 		
 		for (PDefinition def : defs)
 		{
@@ -235,9 +235,9 @@ public class DeclAssistantIR extends AssistantBase
 		SDeclIR postCond = node.getPostCond();
 		String access = node.getAccess();
 		Boolean isAbstract = node.getAbstract();
-		LinkedList<ATemplateTypeIR> templateTypes = node.getTemplateTypes();
+		List<ATemplateTypeIR> templateTypes = node.getTemplateTypes();
 		AMethodTypeIR methodType = node.getMethodType();
-		LinkedList<AFormalParamLocalParamIR> formalParams = node.getFormalParams();
+		List<AFormalParamLocalParamIR> formalParams = node.getFormalParams();
 		String name = node.getName();
 		SExpIR body = node.getBody();
 		SourceNode sourceNode = node.getSourceNode();
@@ -612,8 +612,8 @@ public class DeclAssistantIR extends AssistantBase
 
 		List<PDefinition> allDefs = new LinkedList<PDefinition>();
 
-		LinkedList<PDefinition> defs = classDef.getDefinitions();
-		LinkedList<PDefinition> inheritedDefs = classDef.getAllInheritedDefinitions();
+		List<PDefinition> defs = classDef.getDefinitions();
+		List<PDefinition> inheritedDefs = classDef.getAllInheritedDefinitions();
 
 		allDefs.addAll(defs);
 		allDefs.addAll(inheritedDefs);

--- a/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRGenerator.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRGenerator.java
@@ -109,7 +109,7 @@ public class IRGenerator
 		codeGenInfo.clearTransformationWarnings();
 
 		status.getIrNode().apply(transformation);
-		HashSet<IrNodeInfo> transformationWarnings = new HashSet<IrNodeInfo>(codeGenInfo.getTransformationWarnings());
+		Set<IrNodeInfo> transformationWarnings = new HashSet<IrNodeInfo>(codeGenInfo.getTransformationWarnings());
 
 		status.addTransformationWarnings(transformationWarnings);
 	}
@@ -126,7 +126,7 @@ public class IRGenerator
 		codeGenInfo.clearTransformationWarnings();
 
 		status.getIrNode().apply(trans);
-		HashSet<IrNodeInfo> transformationWarnings = new HashSet<IrNodeInfo>(codeGenInfo.getTransformationWarnings());
+		Set<IrNodeInfo> transformationWarnings = new HashSet<IrNodeInfo>(codeGenInfo.getTransformationWarnings());
 		status.addTransformationWarnings(transformationWarnings);
 		status.setIrNode(trans.getResult());
 	}

--- a/core/codegen/platform/src/main/java/org/overture/codegen/trans/Exp2StmTrans.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/trans/Exp2StmTrans.java
@@ -272,7 +272,7 @@ public class Exp2StmTrans extends DepthFirstAnalysisAdaptor
 		// Replace the let be st expression with the result expression
 		transAssistant.replaceNodeWith(node, letBeStResult);
 
-		LinkedList<SPatternIR> patterns = binding.getPatterns();
+		List<SPatternIR> patterns = binding.getPatterns();
 		ABlockStmIR block = transAssistant.consIterationBlock(patterns, binding.getSet(), tempVarNameGen, strategy, iteVarPrefixes);
 		outerBlock.getStatements().addFirst(block);
 

--- a/core/codegen/platform/src/main/java/org/overture/codegen/trans/LetBeStTrans.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/trans/LetBeStTrans.java
@@ -1,6 +1,7 @@
 package org.overture.codegen.trans;
 
 import java.util.LinkedList;
+import java.util.List;
 
 import org.overture.codegen.ir.SExpIR;
 import org.overture.codegen.ir.SPatternIR;
@@ -57,7 +58,7 @@ public class LetBeStTrans extends DepthFirstAnalysisAdaptor
 			node.setStatement(new ABlockStmIR());
 		}
 
-		LinkedList<SPatternIR> patterns = binding.getPatterns();
+		List<SPatternIR> patterns = binding.getPatterns();
 		ABlockStmIR outerBlock = transAssistant.consIterationBlock(patterns, binding.getSet(), tempVarNameGen, strategy, iteVarPrefixes);
 
 		// Only the statement of the let be st statement is added to the outer block statements.

--- a/core/codegen/platform/src/main/java/org/overture/codegen/trans/funcvalues/FuncValTrans.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/trans/funcvalues/FuncValTrans.java
@@ -121,7 +121,7 @@ public class FuncValTrans extends DepthFirstAnalysisAdaptor
 			functionValueAssistant.registerInterface(lambdaInterface);
 		}
 
-		LinkedList<AFormalParamLocalParamIR> params = node.getParams();
+		List<AFormalParamLocalParamIR> params = node.getParams();
 
 		AInterfaceTypeIR classType = new AInterfaceTypeIR();
 		classType.setName(lambdaInterface.getName());

--- a/core/codegen/platform/src/main/java/org/overture/codegen/trans/patterns/PatternTrans.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/trans/patterns/PatternTrans.java
@@ -833,8 +833,8 @@ public class PatternTrans extends DepthFirstAnalysisAdaptor
 		mismatchHandling(tuplePattern, patternData);
 		initSuccessVar(patternData, tupleCheck, tuplePatternBlock);
 
-		LinkedList<SPatternIR> patterns = tuplePattern.getPatterns();
-		LinkedList<STypeIR> types = tupleType.getTypes();
+		List<SPatternIR> patterns = tuplePattern.getPatterns();
+		List<STypeIR> types = tupleType.getTypes();
 
 		AIfStmIR fieldSizeCheck = new AIfStmIR();
 		fieldSizeCheck.setIfExp(patternData.getSuccessVar().clone());

--- a/core/codegen/platform/src/main/java/org/overture/codegen/visitor/DeclVisitorIR.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/visitor/DeclVisitorIR.java
@@ -224,7 +224,7 @@ public class DeclVisitorIR extends AbstractVisitorIR<IRInfo, SDeclIR>
 			IRInfo question) throws AnalysisException
 	{
 		ILexNameToken name = node.getName();
-		LinkedList<AFieldField> fields = node.getFields();
+		List<AFieldField> fields = node.getFields();
 
 		ARecordDeclIR record = new ARecordDeclIR();
 		record.setName(name.getName());
@@ -235,7 +235,7 @@ public class DeclVisitorIR extends AbstractVisitorIR<IRInfo, SDeclIR>
 			record.setInvariant(invCg);
 		}
 
-		LinkedList<AFieldDeclIR> recordFields = record.getFields();
+		List<AFieldDeclIR> recordFields = record.getFields();
 		for (AFieldField aFieldField : fields)
 		{
 			SDeclIR res = aFieldField.apply(question.getDeclVisitor(), question);
@@ -317,7 +317,7 @@ public class DeclVisitorIR extends AbstractVisitorIR<IRInfo, SDeclIR>
 		Iterator<List<PPattern>> iterator = node.getParamPatternList().iterator();
 		List<PPattern> paramPatterns = iterator.next();
 
-		LinkedList<AFormalParamLocalParamIR> formalParameters = method.getFormalParams();
+		List<AFormalParamLocalParamIR> formalParameters = method.getFormalParams();
 
 		for (int i = 0; i < paramPatterns.size(); i++)
 		{
@@ -383,7 +383,7 @@ public class DeclVisitorIR extends AbstractVisitorIR<IRInfo, SDeclIR>
 
 		// If the function uses any type parameters they will be
 		// registered as part of the method declaration
-		LinkedList<ILexNameToken> typeParams = node.getTypeParams();
+		List<ILexNameToken> typeParams = node.getTypeParams();
 		for (int i = 0; i < typeParams.size(); i++)
 		{
 			ILexNameToken typeParam = typeParams.get(i);
@@ -481,9 +481,9 @@ public class DeclVisitorIR extends AbstractVisitorIR<IRInfo, SDeclIR>
 		}
 		
 		List<PType> ptypes = ((AOperationType) node.getType()).getParameters();
-		LinkedList<PPattern> paramPatterns = node.getParameterPatterns();
+		List<PPattern> paramPatterns = node.getParameterPatterns();
 		
-		LinkedList<AFormalParamLocalParamIR> formalParameters = method.getFormalParams();
+		List<AFormalParamLocalParamIR> formalParameters = method.getFormalParams();
 
 		for (int i = 0; i < ptypes.size(); i++)
 		{
@@ -599,7 +599,7 @@ public class DeclVisitorIR extends AbstractVisitorIR<IRInfo, SDeclIR>
 	public SDeclIR caseAMutexSyncDefinition(AMutexSyncDefinition node,
 			IRInfo question) throws AnalysisException
 	{
-		LinkedList<ILexNameToken> operations = node.getOperations();
+		List<ILexNameToken> operations = node.getOperations();
 		
 		AMutexSyncDeclIR mutexdef = new AMutexSyncDeclIR();
 		

--- a/core/codegen/platform/src/main/java/org/overture/codegen/visitor/ExpVisitorIR.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/visitor/ExpVisitorIR.java
@@ -474,13 +474,13 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 					+ type.getClass().getName() + " at "  + node.getLocation());
 		}
 
-		LinkedList<PExp> members = node.getMembers();
+		List<PExp> members = node.getMembers();
 
 		AEnumSetExpIR enumSet = new AEnumSetExpIR();
 
 		STypeIR typeCg = type.apply(question.getTypeVisitor(), question);
 		enumSet.setType(typeCg);
-		LinkedList<SExpIR> membersCg = enumSet.getMembers();
+		List<SExpIR> membersCg = enumSet.getMembers();
 
 		for (PExp member : members)
 		{
@@ -540,7 +540,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 	public SExpIR caseASetCompSetExp(ASetCompSetExp node, IRInfo question)
 			throws AnalysisException
 	{
-		LinkedList<PMultipleBind> bindings = node.getBindings();
+		List<PMultipleBind> bindings = node.getBindings();
 
 		List<SMultipleBindIR> bindingsCg = new LinkedList<SMultipleBindIR>();
 		for (PMultipleBind multipleBind : bindings)
@@ -595,7 +595,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 		PType type = node.getType();
 		PExp exp = node.getExpression();
 		PExp others = node.getOthers();
-		LinkedList<ACaseAlternative> cases = node.getCases();
+		List<ACaseAlternative> cases = node.getCases();
 
 		STypeIR typeCg = type.apply(question.getTypeVisitor(), question);
 		SExpIR expCg = exp.apply(question.getExpVisitor(), question);
@@ -644,7 +644,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 		ternaryIf.setTrueValue(thenExp);
 		ternaryIf.setType(expectedType);
 
-		LinkedList<AElseIfExp> elseExpList = node.getElseList();
+		List<AElseIfExp> elseExpList = node.getElseList();
 
 		ATernaryIfExpIR nextTernaryIf = ternaryIf;
 
@@ -681,7 +681,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 			throws AnalysisException
 	{
 		PType type = node.getType();
-		LinkedList<PExp> args = node.getArgs();
+		List<PExp> args = node.getArgs();
 
 		STypeIR typeCg = type.apply(question.getTypeVisitor(), question);
 
@@ -736,7 +736,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 
 		AMethodInstantiationExpIR methodInst = new AMethodInstantiationExpIR();
 
-		LinkedList<PType> actualTypes = node.getActualTypes();
+		List<PType> actualTypes = node.getActualTypes();
 		for (PType actualType : actualTypes)
 		{
 			STypeIR actualTypeCg = actualType.apply(question.getTypeVisitor(), question);
@@ -872,13 +872,13 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 
 		ARecordTypeIR recordTypeCg = (ARecordTypeIR) typeCg;
 
-		LinkedList<PExp> nodeArgs = node.getArgs();
+		List<PExp> nodeArgs = node.getArgs();
 
 		ANewExpIR newExp = new ANewExpIR();
 		newExp.setType(recordTypeCg);
 		newExp.setName(recordTypeCg.getName().clone());
 
-		LinkedList<SExpIR> newExpArgs = newExp.getArgs();
+		List<SExpIR> newExpArgs = newExp.getArgs();
 
 		for (PExp arg : nodeArgs)
 		{
@@ -1040,7 +1040,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 		AEnumMapExpIR enumMap = new AEnumMapExpIR();
 		enumMap.setType(typeCg);
 
-		LinkedList<AMapletExp> members = node.getMembers();
+		List<AMapletExp> members = node.getMembers();
 		for (PExp member : members)
 		{
 			SExpIR memberCg = member.apply(question.getExpVisitor(), question);
@@ -1086,7 +1086,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 	public SExpIR caseAMapCompMapExp(AMapCompMapExp node, IRInfo question)
 			throws AnalysisException
 	{
-		LinkedList<PMultipleBind> bindings = node.getBindings();
+		List<PMultipleBind> bindings = node.getBindings();
 		PType type = node.getType();
 		AMapletExp first = node.getFirst();
 		PExp predicate = node.getPredicate();
@@ -1242,7 +1242,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 			return null;
 		}
 
-		LinkedList<PExp> members = node.getMembers();
+		List<PExp> members = node.getMembers();
 		for (PExp member : members)
 		{
 			SExpIR memberCg = member.apply(question.getExpVisitor(), question);
@@ -1463,7 +1463,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 		typeName.setName(className);
 
 		PType type = node.getType();
-		LinkedList<PExp> nodeArgs = node.getArgs();
+		List<PExp> nodeArgs = node.getArgs();
 
 		ANewExpIR newExp = new ANewExpIR();
 
@@ -1471,7 +1471,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 		newExp.setType(typeCg);
 		newExp.setName(typeName);
 
-		LinkedList<SExpIR> newExpArgs = newExp.getArgs();
+		List<SExpIR> newExpArgs = newExp.getArgs();
 		for (PExp arg : nodeArgs)
 		{
 			SExpIR argCg = arg.apply(question.getExpVisitor(), question);
@@ -1841,7 +1841,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 	public SExpIR caseALambdaExp(ALambdaExp node, IRInfo question)
 			throws AnalysisException
 	{
-		LinkedList<ATypeBind> bindList = node.getBindList();
+		List<ATypeBind> bindList = node.getBindList();
 		PExp exp = node.getExpression();
 		PType type = node.getType();
 
@@ -1853,7 +1853,7 @@ public class ExpVisitorIR extends AbstractVisitorIR<IRInfo, SExpIR>
 		lambdaExp.setType(typeCg);
 		lambdaExp.setExp(expCg);
 
-		LinkedList<AFormalParamLocalParamIR> params = lambdaExp.getParams();
+		List<AFormalParamLocalParamIR> params = lambdaExp.getParams();
 
 		for (ATypeBind typeBind : bindList)
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/nextgen/NextGenRTLogger.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/nextgen/NextGenRTLogger.java
@@ -714,7 +714,7 @@ public class NextGenRTLogger implements IRTLogger
 			events.put(eventTime.getAbsoluteTime(), new ArrayList<INextGenEvent>());
 		}
 
-		ArrayList<INextGenEvent> eventList = events.get(eventTime.getAbsoluteTime());
+		List<INextGenEvent> eventList = events.get(eventTime.getAbsoluteTime());
 		eventList.add(event);
 	}
 

--- a/core/pog/src/main/java/org/overture/pog/visitors/PogParamExpVisitor.java
+++ b/core/pog/src/main/java/org/overture/pog/visitors/PogParamExpVisitor.java
@@ -731,7 +731,7 @@ public class PogParamExpVisitor<Q extends IPOContextStack, A extends IProofOblig
 		IProofObligationList obligations = node.getRecord().apply(rootVisitor, question);
 		Queue<ARecordModifier> modifiers = node.getModifiers();
 		ARecordInvariantType recordType = node.getRecordType();
-		LinkedList<PType> mTypes = node.getModTypes();
+		List<PType> mTypes = node.getModTypes();
 
 		int i = 0;
 		for (ARecordModifier mod : modifiers)

--- a/core/typechecker/src/main/java/org/overture/typechecker/util/LexNameTokenMap.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/util/LexNameTokenMap.java
@@ -39,7 +39,7 @@ public class LexNameTokenMap<V> implements Map<ILexNameToken, V>, Serializable
 	 */
 	private static final long serialVersionUID = -1122692848887584905L;
 
-	private final HashMap<LexNameTokenWrapper, V> map = new HashMap<LexNameTokenWrapper, V>();
+	private final Map<LexNameTokenWrapper, V> map = new HashMap<LexNameTokenWrapper, V>();
 
 	public V put(ILexNameToken key, V value)
 	{


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1319 - “Declarations should use Java collection interfaces such as "List" rather than specific implementation classes such as "LinkedList" ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
Please let me know if you have any questions.
Ayman Abdelghany.
