### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/MapUtil.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/MapUtil.java
@@ -288,7 +288,7 @@ public class MapUtil
 
 		VDMMap result = map();
 
-		if (vdmMap.size() == 0)
+		if (vdmMap.isEmpty())
 		{
 			return result;
 		}

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenUtil.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenUtil.java
@@ -67,7 +67,7 @@ public class JavaCodeGenUtil
 		Settings.dialect = dialect;
 		TypeCheckResult<PExp> typeCheckResult = GeneralCodeGenUtils.validateExp(exp);
 
-		if (typeCheckResult.errors.size() > 0)
+		if (!typeCheckResult.errors.isEmpty())
 		{
 			throw new AnalysisException("Unable to type check expression: "
 					+ exp);

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaFormat.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaFormat.java
@@ -797,7 +797,7 @@ public class JavaFormat
 
 		sb.append("new String(new char[]{");
 
-		if (exps.size() > 0)
+		if (!exps.isEmpty())
 		{
 			sb.append(format(exps.get(0)));
 

--- a/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRStatus.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRStatus.java
@@ -69,7 +69,7 @@ public final class IRStatus<T extends PIR>
 
 	public boolean canBeGenerated()
 	{
-		return unsupportedInIr.size() == 0;
+		return unsupportedInIr.isEmpty();
 	}
 
 	public Set<IrNodeInfo> getTransformationWarnings()

--- a/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralCodeGenUtils.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralCodeGenUtils.java
@@ -186,7 +186,7 @@ public class GeneralCodeGenUtils
 					+ ". Message: " + e.getMessage());
 		}
 
-		if (parseResult.errors.size() > 0)
+		if (!parseResult.errors.isEmpty())
 		{
 			throw new AnalysisException("Unable to parse expression: " + exp);
 		}

--- a/core/interpreter/src/main/java/org/overture/interpreter/eval/ExpressionEvaluator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/eval/ExpressionEvaluator.java
@@ -1248,7 +1248,7 @@ public class ExpressionEvaluator extends BinaryExpressionEvaluator
 
 				ObjectValue subself = ctxt.assistantFactory.createAPostOpExpAssistant().findObject(node, node.getOpname().getModule(), self);
 
-				if (self.superobjects.size() == 0)
+				if (self.superobjects.isEmpty())
 				{
 					subself = self;
 				}

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/BasicRuntimeValidator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/BasicRuntimeValidator.java
@@ -80,7 +80,7 @@ public class BasicRuntimeValidator implements IRuntimeValidatior
 			return;
 		}
 
-		if (conjectures.size() > 0)
+		if (!conjectures.isEmpty())
 		{
 			ISchedulableThread ct = BasicSchedulableThread.getThread(Thread.currentThread());
 
@@ -191,7 +191,7 @@ public class BasicRuntimeValidator implements IRuntimeValidatior
 
 	public void validateAsync(OperationValue op, AsyncThread t)
 	{
-		if (conjectures.size() > 0)
+		if (!conjectures.isEmpty())
 		{
 
 			for (ConjectureDefinition conj : conjectures)

--- a/core/pog/src/main/java/org/overture/pog/contexts/OpPostConditionContext.java
+++ b/core/pog/src/main/java/org/overture/pog/contexts/OpPostConditionContext.java
@@ -64,7 +64,7 @@ public class OpPostConditionContext extends StatefulContext implements
 			try
 			{
 				invariants = calledOp.getClassDefinition().apply(af.getInvExpGetVisitor());
-				if (invariants.size() > 0)
+				if (!invariants.isEmpty())
 				{
 
 					PExp inv = invariants.get(0).clone();

--- a/core/testframework/src/main/java/org/overture/test/framework/results/Result.java
+++ b/core/testframework/src/main/java/org/overture/test/framework/results/Result.java
@@ -40,7 +40,7 @@ public class Result<R>
 	public String toString()
 	{
 		StringBuffer buf = new StringBuffer();
-		if (errors.size() > 0)
+		if (!errors.isEmpty())
 		{
 			buf.append("Errors:\n");
 			for (IMessage m : errors)
@@ -49,7 +49,7 @@ public class Result<R>
 			}
 		}
 
-		if (warnings.size() > 0)
+		if (!warnings.isEmpty())
 		{
 			buf.append("Warnings:\n");
 			for (IMessage m : warnings)

--- a/core/testing/exsupport/src/main/java/org/overture/core/tests/examples/ExamplesUtility.java
+++ b/core/testing/exsupport/src/main/java/org/overture/core/tests/examples/ExamplesUtility.java
@@ -182,7 +182,7 @@ abstract public class ExamplesUtility {
 							DirectoryFileFilter.DIRECTORY);
 					source.addAll(files);
 
-					if (p.getLibs().size() > 0) {
+					if (!p.getLibs().isEmpty()) {
 						for (String lib : p.getLibs()) {
 							source.add(new File(externalsRoot + LIBS_ROOT
 									+ ExamplePacker.getName(dialect) + "/"

--- a/core/typechecker/src/main/java/org/overture/typechecker/TypeCheckInfo.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/TypeCheckInfo.java
@@ -58,7 +58,7 @@ public class TypeCheckInfo
 		if (o instanceof List<?>)
 		{
 			List<?> list = List.class.cast(o);
-			if (list.size() > 0)
+			if (!list.isEmpty())
 			{
 				Object first = list.get(0);
 				if (first != null && clz.isInstance(first))

--- a/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerExpVisitor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerExpVisitor.java
@@ -1515,7 +1515,7 @@ public class TypeCheckerExpVisitor extends AbstractTypeCheckVisitor
 						continue;
 					}
 
-					if (typeParams.size() == 0)
+					if (typeParams.isEmpty())
 					{
 						TypeCheckerErrors.concern(serious, 3100, "Function has no type parameters", node.getLocation(), node);
 						continue;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.
