### PR TITLE
The operator ("<>") should be used.

### DIFF
--- a/core/ast/src/main/java/org/overture/ast/assistant/pattern/PPatternAssistant.java
+++ b/core/ast/src/main/java/org/overture/ast/assistant/pattern/PPatternAssistant.java
@@ -60,7 +60,7 @@ public class PPatternAssistant implements IAstAssistant
 
 	public LexNameList getVariableNamesBaseCase(PPattern pattern)
 	{
-		Set<ILexNameToken> set = new HashSet<ILexNameToken>();
+		Set<ILexNameToken> set = new HashSet<>();
 		set.addAll(af.createPPatternAssistant().getAllVariableNames(pattern));
 		LexNameList list = new LexNameList();
 		list.addAll(set);

--- a/core/ast/src/main/java/org/overture/ast/factory/AstFactory.java
+++ b/core/ast/src/main/java/org/overture/ast/factory/AstFactory.java
@@ -1018,7 +1018,7 @@ public class AstFactory
 		// Definition initialization
 		initDefinition(result, Pass.DEFS, location, new LexNameToken(location.getModule(), Utils.listToString(pathname, "_"), location), NameScope.GLOBAL);
 
-		List<ClonableString> namesClonable = new Vector<ClonableString>();
+		List<ClonableString> namesClonable = new Vector<>();
 		for (String string : pathname)
 		{
 			namesClonable.add(new ClonableString(string));
@@ -2136,7 +2136,7 @@ public class AstFactory
 		result.setTypeChecked(false);
 		result.setIsDLModule(false); // TODO: this does not exist in VDMj
 
-		List<ClonableFile> files = new Vector<ClonableFile>();
+		List<ClonableFile> files = new Vector<>();
 		if (file != null)
 		{
 			files.add(new ClonableFile(file));
@@ -2178,7 +2178,7 @@ public class AstFactory
 		result.setExports(exports);
 		result.setDefs(defs);
 
-		List<ClonableFile> files = new Vector<ClonableFile>();
+		List<ClonableFile> files = new Vector<>();
 		files.add(new ClonableFile(name.location.getFile()));
 		result.setFiles(files);
 		result.setIsFlat(false);

--- a/core/ast/src/main/java/org/overture/ast/lex/LexBooleanToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexBooleanToken.java
@@ -105,7 +105,7 @@ public class LexBooleanToken extends LexToken implements ILexBooleanToken
 	@Override
 	public Map<String, Object> getChildren(Boolean includeInheritedFields)
 	{
-		Map<String, Object> fields = new HashMap<String, Object>();
+		Map<String, Object> fields = new HashMap<>();
 		if (includeInheritedFields)
 		{
 			fields.putAll(super.getChildren(includeInheritedFields));

--- a/core/ast/src/main/java/org/overture/ast/lex/LexCharacterToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexCharacterToken.java
@@ -102,7 +102,7 @@ public class LexCharacterToken extends LexToken implements ILexCharacterToken
 	@Override
 	public Map<String, Object> getChildren(Boolean includeInheritedFields)
 	{
-		Map<String, Object> fields = new HashMap<String, Object>();
+		Map<String, Object> fields = new HashMap<>();
 		if (includeInheritedFields)
 		{
 			fields.putAll(super.getChildren(includeInheritedFields));

--- a/core/ast/src/main/java/org/overture/ast/lex/LexIdentifierToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexIdentifierToken.java
@@ -144,7 +144,7 @@ public class LexIdentifierToken extends LexToken implements ILexIdentifierToken
 	@Override
 	public Map<String, Object> getChildren(Boolean includeInheritedFields)
 	{
-		Map<String, Object> fields = new HashMap<String, Object>();
+		Map<String, Object> fields = new HashMap<>();
 		if (includeInheritedFields)
 		{
 			fields.putAll(super.getChildren(includeInheritedFields));

--- a/core/ast/src/main/java/org/overture/ast/lex/LexIntegerToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexIntegerToken.java
@@ -105,7 +105,7 @@ public class LexIntegerToken extends LexToken implements ILexIntegerToken
 	@Override
 	public Map<String, Object> getChildren(Boolean includeInheritedFields)
 	{
-		Map<String, Object> fields = new HashMap<String, Object>();
+		Map<String, Object> fields = new HashMap<>();
 		if (includeInheritedFields)
 		{
 			fields.putAll(super.getChildren(includeInheritedFields));

--- a/core/ast/src/main/java/org/overture/ast/lex/LexLocation.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexLocation.java
@@ -59,13 +59,13 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 	private static final long serialVersionUID = 1L;
 
 	/** A collection of all LexLocation objects. */
-	private static List<LexLocation> allLocations = new Vector<LexLocation>();
+	private static List<LexLocation> allLocations = new Vector<>();
 
 	/** A unique map of LexLocation objects, for rapid searching. */
-	private static Map<LexLocation, LexLocation> uniqueLocations = new HashMap<LexLocation, LexLocation>();
+	private static Map<LexLocation, LexLocation> uniqueLocations = new HashMap<>();
 
 	/** A map of f/op/class names to their lexical span, for coverage. */
-	private static Map<LexNameToken, LexLocation> nameSpans = new HashMap<LexNameToken, LexLocation>();// TODO
+	private static Map<LexNameToken, LexLocation> nameSpans = new HashMap<>();// TODO
 
 	/** True if the location is executable. */
 	private boolean executable = false;
@@ -322,12 +322,12 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 	{
 		synchronized (allLocations)
 		{
-			allLocations = new Vector<LexLocation>();
+			allLocations = new Vector<>();
 		}
 
 		synchronized (uniqueLocations)
 		{
-			uniqueLocations = new HashMap<LexLocation, LexLocation>();
+			uniqueLocations = new HashMap<>();
 		}
 
 		// synchronized (locationToAstNode)
@@ -453,7 +453,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 	{
 		//FIXME skip lex location in other files
 		// idea: if !lextLocation.getFile().equals(file) then continue; 
-		List<Integer> hits = new Vector<Integer>();
+		List<Integer> hits = new Vector<>();
 
 		synchronized (allLocations)
 		{
@@ -471,7 +471,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 	public static List<Integer> getMissList(File file)
 	{
-		List<Integer> misses = new Vector<Integer>();
+		List<Integer> misses = new Vector<>();
 
 		synchronized (allLocations)
 		{
@@ -489,7 +489,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 	public static List<Integer> getSourceList(File file)
 	{
-		List<Integer> lines = new Vector<Integer>();
+		List<Integer> lines = new Vector<>();
 		int last = 0;
 
 		synchronized (allLocations)
@@ -509,7 +509,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 	public static Map<Integer, List<LexLocation>> getHitLocations(File file)
 	{
-		Map<Integer, List<LexLocation>> map = new HashMap<Integer, List<LexLocation>>();
+		Map<Integer, List<LexLocation>> map = new HashMap<>();
 
 		synchronized (allLocations)
 		{
@@ -521,7 +521,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 					if (list == null)
 					{
-						list = new Vector<LexLocation>();
+						list = new Vector<>();
 						map.put(l.startLine, list);
 					}
 
@@ -561,7 +561,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 	public static Map<Integer, List<LexLocation>> getMissLocations(File file)
 	{
-		Map<Integer, List<LexLocation>> map = new HashMap<Integer, List<LexLocation>>();
+		Map<Integer, List<LexLocation>> map = new HashMap<>();
 
 		synchronized (allLocations)
 		{
@@ -573,7 +573,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 					if (list == null)
 					{
-						list = new Vector<LexLocation>();
+						list = new Vector<>();
 						map.put(l.startLine, list);
 					}
 
@@ -587,7 +587,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 
 	public static List<LexLocation> getSourceLocations(File file)
 	{
-		List<LexLocation> locations = new Vector<LexLocation>();
+		List<LexLocation> locations = new Vector<>();
 
 		synchronized (allLocations)
 		{
@@ -650,7 +650,7 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 	 */
 	public static List<LexLocation> removeDuplicates(List<LexLocation> locations)
 	{
-		List<LexLocation> tmp = new Vector<LexLocation>();
+		List<LexLocation> tmp = new Vector<>();
 		c: for (LexLocation l1 : locations)
 		{
 			if (l1.hits == 0)

--- a/core/ast/src/main/java/org/overture/ast/lex/LexLocationUtils.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexLocationUtils.java
@@ -45,13 +45,13 @@ public class LexLocationUtils implements Serializable
 	private static final long serialVersionUID = 1L;
 
 	/** A collection of all LexLocation objects. */
-	private static List<ILexLocation> allLocations = new Vector<ILexLocation>();
+	private static List<ILexLocation> allLocations = new Vector<>();
 
 	/** A collection of all LexLocation objects to the AstNodes. */
 	private static Map<ILexLocation, INode> locationToAstNode = new Hashtable<ILexLocation, INode>();
 
 	/** A map of f/op/class names to their lexical span, for coverage. */
-	private static Map<LexNameToken, ILexLocation> nameSpans = new HashMap<LexNameToken, ILexLocation>();// TODO
+	private static Map<LexNameToken, ILexLocation> nameSpans = new HashMap<>();// TODO
 
 	public static void clearLocations()
 	{
@@ -68,7 +68,7 @@ public class LexLocationUtils implements Serializable
 	{
 		synchronized (allLocations)
 		{
-			allLocations = new Vector<ILexLocation>();
+			allLocations = new Vector<>();
 		}
 
 		synchronized (locationToAstNode)
@@ -193,7 +193,7 @@ public class LexLocationUtils implements Serializable
 
 	public static List<Integer> getHitList(File file)
 	{
-		List<Integer> hits = new Vector<Integer>();
+		List<Integer> hits = new Vector<>();
 
 		synchronized (allLocations)
 		{
@@ -211,7 +211,7 @@ public class LexLocationUtils implements Serializable
 
 	public static List<Integer> getMissList(File file)
 	{
-		List<Integer> misses = new Vector<Integer>();
+		List<Integer> misses = new Vector<>();
 
 		synchronized (allLocations)
 		{
@@ -229,7 +229,7 @@ public class LexLocationUtils implements Serializable
 
 	public static List<Integer> getSourceList(File file)
 	{
-		List<Integer> lines = new Vector<Integer>();
+		List<Integer> lines = new Vector<>();
 		int last = 0;
 
 		synchronized (allLocations)
@@ -250,7 +250,7 @@ public class LexLocationUtils implements Serializable
 
 	public static Map<Integer, List<ILexLocation>> getHitLocations(File file)
 	{
-		Map<Integer, List<ILexLocation>> map = new HashMap<Integer, List<ILexLocation>>();
+		Map<Integer, List<ILexLocation>> map = new HashMap<>();
 
 		synchronized (allLocations)
 		{
@@ -263,7 +263,7 @@ public class LexLocationUtils implements Serializable
 
 					if (list == null)
 					{
-						list = new Vector<ILexLocation>();
+						list = new Vector<>();
 						map.put(l.getStartLine(), list);
 					}
 
@@ -303,7 +303,7 @@ public class LexLocationUtils implements Serializable
 
 	public static Map<Integer, List<ILexLocation>> getMissLocations(File file)
 	{
-		Map<Integer, List<ILexLocation>> map = new HashMap<Integer, List<ILexLocation>>();
+		Map<Integer, List<ILexLocation>> map = new HashMap<>();
 
 		synchronized (allLocations)
 		{
@@ -316,7 +316,7 @@ public class LexLocationUtils implements Serializable
 
 					if (list == null)
 					{
-						list = new Vector<ILexLocation>();
+						list = new Vector<>();
 						map.put(l.getStartLine(), list);
 					}
 
@@ -330,7 +330,7 @@ public class LexLocationUtils implements Serializable
 
 	public static List<ILexLocation> getSourceLocations(File file)
 	{
-		List<ILexLocation> locations = new Vector<ILexLocation>();
+		List<ILexLocation> locations = new Vector<>();
 
 		synchronized (allLocations)
 		{

--- a/core/ast/src/main/java/org/overture/ast/lex/LexNameToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexNameToken.java
@@ -369,7 +369,7 @@ public class LexNameToken extends LexToken implements ILexNameToken,
 	@Override
 	public Map<String, Object> getChildren(Boolean includeInheritedFields)
 	{
-		Map<String, Object> fields = new HashMap<String, Object>();
+		Map<String, Object> fields = new HashMap<>();
 		if (includeInheritedFields)
 		{
 			fields.putAll(super.getChildren(includeInheritedFields));

--- a/core/ast/src/main/java/org/overture/ast/lex/LexQuoteToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexQuoteToken.java
@@ -99,7 +99,7 @@ public class LexQuoteToken extends LexToken implements ILexQuoteToken
 	@Override
 	public Map<String, Object> getChildren(Boolean includeInheritedFields)
 	{
-		Map<String, Object> fields = new HashMap<String, Object>();
+		Map<String, Object> fields = new HashMap<>();
 		if (includeInheritedFields)
 		{
 			fields.putAll(super.getChildren(includeInheritedFields));

--- a/core/ast/src/main/java/org/overture/ast/lex/LexRealToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexRealToken.java
@@ -105,7 +105,7 @@ public class LexRealToken extends LexToken implements ILexRealToken
 	@Override
 	public Map<String, Object> getChildren(Boolean includeInheritedFields)
 	{
-		Map<String, Object> fields = new HashMap<String, Object>();
+		Map<String, Object> fields = new HashMap<>();
 		if (includeInheritedFields)
 		{
 			fields.putAll(super.getChildren(includeInheritedFields));

--- a/core/ast/src/main/java/org/overture/ast/lex/LexStringToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexStringToken.java
@@ -99,7 +99,7 @@ public class LexStringToken extends LexToken implements ILexStringToken
 	@Override
 	public Map<String, Object> getChildren(Boolean includeInheritedFields)
 	{
-		Map<String, Object> fields = new HashMap<String, Object>();
+		Map<String, Object> fields = new HashMap<>();
 		if (includeInheritedFields)
 		{
 			fields.putAll(super.getChildren(includeInheritedFields));

--- a/core/ast/src/main/java/org/overture/ast/lex/LexToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexToken.java
@@ -163,7 +163,7 @@ public class LexToken extends Node implements ILexToken, Serializable
 	@Override
 	public Map<String, Object> getChildren(Boolean includeInheritedFields)
 	{
-		Map<String, Object> fields = new HashMap<String, Object>();
+		Map<String, Object> fields = new HashMap<>();
 		if (includeInheritedFields)
 		{
 			fields.putAll(super.getChildren(includeInheritedFields));

--- a/core/ast/src/main/java/org/overture/ast/lex/VDMToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/VDMToken.java
@@ -230,9 +230,9 @@ public enum VDMToken implements Serializable
 		// initializes its members before any statics (or member inits)
 		// are performed.
 
-		sltokens = new HashMap<String, VDMToken>(256);
-		pptokens = new HashMap<String, VDMToken>(256);
-		rttokens = new HashMap<String, VDMToken>(256);
+		sltokens = new HashMap<>(256);
+		pptokens = new HashMap<>(256);
+		rttokens = new HashMap<>(256);
 
 		for (VDMToken token : values())
 		{

--- a/core/ast/src/main/java/org/overture/ast/preview/DotGraphVisitor.java
+++ b/core/ast/src/main/java/org/overture/ast/preview/DotGraphVisitor.java
@@ -62,14 +62,14 @@ public class DotGraphVisitor extends QuestionAdaptor<DotGraphVisitor.DotPair>
 
 		public String id;
 		public String name;
-		public Map<String, Object> childToId = new HashMap<String, Object>();
+		public Map<String, Object> childToId = new HashMap<>();
 	}
 
 	private StringBuilder resultString;
 	public boolean showNullPointers = false;
 	Set<INode> visitedNodes = null;
 
-	Set<String> filterClassNames = new HashSet<String>();
+	Set<String> filterClassNames = new HashSet<>();
 
 	public DotGraphVisitor()
 	{
@@ -145,7 +145,7 @@ public class DotGraphVisitor extends QuestionAdaptor<DotGraphVisitor.DotPair>
 		{
 			tmp += " |{";
 			boolean firstChild = true;
-			Map<String, Object> children = new HashMap<String, Object>();
+			Map<String, Object> children = new HashMap<>();
 			String nt = node.toString();
 			if (nt.length() > 150)
 			{

--- a/core/ast/src/main/java/org/overture/ast/preview/Main.java
+++ b/core/ast/src/main/java/org/overture/ast/preview/Main.java
@@ -53,7 +53,7 @@ public class Main
 
 	public static File dot = null;
 
-	public static Set<String> filterClassNames = new HashSet<String>();
+	public static Set<String> filterClassNames = new HashSet<>();
 
 	// digraph ast
 	// {

--- a/core/ast/src/main/java/org/overture/ast/util/ToStringUtil.java
+++ b/core/ast/src/main/java/org/overture/ast/util/ToStringUtil.java
@@ -112,7 +112,7 @@ public class ToStringUtil
 
 	private static List<String> getString(List<APatternListTypePair> node)
 	{
-		List<String> list = new Vector<String>();
+		List<String> list = new Vector<>();
 		for (APatternListTypePair pl : node)
 		{
 			list.add("(" + getStringPattern(pl.getPatterns()) + ":"

--- a/core/ast/src/main/java/org/overture/ast/util/definitions/ClassList.java
+++ b/core/ast/src/main/java/org/overture/ast/util/definitions/ClassList.java
@@ -84,7 +84,7 @@ public class ClassList extends Vector<SClassDefinition>
 
 	public Set<File> getSourceFiles()
 	{
-		Set<File> files = new HashSet<File>();
+		Set<File> files = new HashSet<>();
 
 		for (SClassDefinition def : this)
 		{

--- a/core/ast/src/main/java/org/overture/ast/util/modules/CombinedDefaultModule.java
+++ b/core/ast/src/main/java/org/overture/ast/util/modules/CombinedDefaultModule.java
@@ -79,7 +79,7 @@ public class CombinedDefaultModule extends AModuleModules
 	@Override
 	public List<? extends ClonableFile> getFiles()
 	{
-		LinkedList<ClonableFile> allFiles = new LinkedList<ClonableFile>();
+		LinkedList<ClonableFile> allFiles = new LinkedList<>();
 
 		for (AModuleModules m : modules)
 		{

--- a/core/ast/src/main/java/org/overture/ast/util/modules/ModuleList.java
+++ b/core/ast/src/main/java/org/overture/ast/util/modules/ModuleList.java
@@ -63,7 +63,7 @@ public class ModuleList extends Vector<AModuleModules>
 
 	public Set<File> getSourceFiles()
 	{
-		Set<File> files = new HashSet<File>();
+		Set<File> files = new HashSet<>();
 
 		for (AModuleModules def : this)
 		{
@@ -165,7 +165,7 @@ public class ModuleList extends Vector<AModuleModules>
 	// This function is copied from the module reader
 	private AFromModuleImports importAll(ILexIdentifierToken from)
 	{
-		List<List<PImport>> types = new Vector<List<PImport>>();
+		List<List<PImport>> types = new Vector<>();
 		ILexNameToken all = new LexNameToken(from.getName(), "all", from.getLocation());
 		List<PImport> impAll = new Vector<PImport>();
 		AAllImport iport = AstFactory.newAAllImport(all);

--- a/core/codegen/codegen-maven-plugin/src/main/java/org/overture/codegen/mojocg/Vdm2JavaMojo.java
+++ b/core/codegen/codegen-maven-plugin/src/main/java/org/overture/codegen/mojocg/Vdm2JavaMojo.java
@@ -82,7 +82,7 @@ public class Vdm2JavaMojo extends Vdm2JavaBaseMojo
 			}
 		}
 
-		List<File> files = new LinkedList<File>();
+		List<File> files = new LinkedList<>();
 		
 		if (specificationDir != null && specificationDir.isDirectory())
 		{
@@ -97,7 +97,7 @@ public class Vdm2JavaMojo extends Vdm2JavaBaseMojo
 
 		outputDirectory.mkdirs();
 
-		List<File> tmp = new Vector<File>();
+		List<File> tmp = new Vector<>();
 		tmp.addAll(files);
 		
 		if(release.equals(VDM_10))
@@ -200,7 +200,7 @@ public class Vdm2JavaMojo extends Vdm2JavaBaseMojo
 			return new HashMap<>();
 		}
 		
-		Map<String, String> map = new HashMap<String, String>();
+		Map<String, String> map = new HashMap<>();
 		for (String key : delegates.stringPropertyNames()) {
 		    map.put(key, delegates.getProperty(key));
 		}

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/AlternativeTraceNode.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/AlternativeTraceNode.java
@@ -42,7 +42,7 @@ public class AlternativeTraceNode extends TraceNode implements
 
 	public AlternativeTraceNode()
 	{
-		this.alternatives = new Vector<TraceNode>();
+		this.alternatives = new Vector<>();
 	}
 
 	@Override
@@ -90,7 +90,7 @@ public class AlternativeTraceNode extends TraceNode implements
 			return indics.size();
 		}
 		
-		indics = new HashMap<Integer, Pair<Integer, Integer>>();
+		indics = new HashMap<>();
 		int k=0;
 		
 		for (TraceNode node : alternatives)
@@ -109,7 +109,7 @@ public class AlternativeTraceNode extends TraceNode implements
 			
 			for (int i = 0; i < s; i++)
 			{
-				indics.put(size+i, new Pair<Integer,Integer>(k,i));
+				indics.put(size+i, new Pair<>(k, i));
 			}
 			
 			size+=s;

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/ConcurrentTraceNode.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/ConcurrentTraceNode.java
@@ -41,7 +41,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 
 	public ConcurrentTraceNode()
 	{
-		nodes = new Vector<TraceNode>();
+		nodes = new Vector<>();
 	}
 
 	@Override
@@ -53,7 +53,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 		}
 		Pair<Integer, Integer> v = indics.get(index);
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new Vector<>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)
@@ -126,11 +126,11 @@ public class ConcurrentTraceNode extends TraceNode implements
 			return indics.size();
 		}
 
-		indics = new HashMap<Integer, Pair<Integer, Integer>>();
+		indics = new HashMap<>();
 
 		int size = 0;
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new Vector<>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)
@@ -159,7 +159,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 			{
 				j++;
 				p.next();
-				indics.put(size, new Pair<Integer, Integer>(r, j));
+				indics.put(size, new Pair<>(r, j));
 				size++;
 			}
 		}

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/InMemoryTestAccumulator.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/InMemoryTestAccumulator.java
@@ -13,7 +13,7 @@ public class InMemoryTestAccumulator implements TestAccumulator
 
 	public InMemoryTestAccumulator()
 	{
-		this.tests = new LinkedList<TraceTest>();
+		this.tests = new LinkedList<>();
 		this.nextIdx = 0;
 	}
 

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/RepeatTraceNode.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/RepeatTraceNode.java
@@ -126,7 +126,7 @@ public class RepeatTraceNode extends TraceNode implements IIterableTraceNode
 			return indics.size();
 		}
 
-		indics = new HashMap<Integer, Pair<Integer, Integer>>();
+		indics = new HashMap<>();
 
 		int size = 0;
 		TestSequence rtests = repeat.getTests();
@@ -136,7 +136,7 @@ public class RepeatTraceNode extends TraceNode implements IIterableTraceNode
 			if (r == 0)
 			{
 
-				indics.put(size, new Pair<Integer, Integer>(r, 0));
+				indics.put(size, new Pair<>(r, 0));
 				size++;
 				continue;
 			}
@@ -155,7 +155,7 @@ public class RepeatTraceNode extends TraceNode implements IIterableTraceNode
 			{
 				j++;
 				p.next();
-				indics.put(size, new Pair<Integer, Integer>(r, j));
+				indics.put(size, new Pair<>(r, j));
 				size++;
 			}
 		}

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/SequenceTraceNode.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/SequenceTraceNode.java
@@ -41,7 +41,7 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 
 	public SequenceTraceNode()
 	{
-		this.nodes = new Vector<TraceNode>();
+		this.nodes = new Vector<>();
 	}
 
 	@Override
@@ -55,7 +55,7 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 
 		CallSequence seq = getVars();
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new Vector<>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)
@@ -91,9 +91,9 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 			return indics.size();
 		}
 
-		indics = new HashMap<Integer, Integer[]>();
+		indics = new HashMap<>();
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new Vector<>();
 		int count = nodes.size();
 		int[] sizes = new int[count];
 		int n = 0;

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/TestSequence.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/TestSequence.java
@@ -44,7 +44,7 @@ public class TestSequence extends Vector<CallSequence>
 		}
 	}
 
-	final List<TestData> failedCallSeqs = new Vector<TestData>();
+	final List<TestData> failedCallSeqs = new Vector<>();
 
 	/**
 	 * Filter remaining tests based on one set of results. The result list passed in is the result of running the test,

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/TraceNode.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/traces/TraceNode.java
@@ -86,8 +86,8 @@ public abstract class TraceNode
 				 * it, e.g. let a = opWithSideEffects() in ....
 				 */
 				store.reset();
-				List<String> callStms = new LinkedList<String>();
-				List<Object> callStmResults = new LinkedList<Object>();
+				List<String> callStms = new LinkedList<>();
+				List<Object> callStmResults = new LinkedList<>();
 
 				/*
 				 * TODO: Type check missing here If the type check fails we would also have to do filtering

--- a/core/codegen/codegen-runtime/src/test/java/PermuteArrayTest.java
+++ b/core/codegen/codegen-runtime/src/test/java/PermuteArrayTest.java
@@ -11,7 +11,7 @@ public class PermuteArrayTest
 	{
 		PermuteArray p = new PermuteArray(n);
 		
-		List<int[]> intArrays = new LinkedList<int[]>();
+		List<int[]> intArrays = new LinkedList<>();
 		
 		while(p.hasNext())
 		{

--- a/core/codegen/codegen-runtime/src/test/java/PermutorTest.java
+++ b/core/codegen/codegen-runtime/src/test/java/PermutorTest.java
@@ -12,7 +12,7 @@ public class PermutorTest
 	{
 		Permutor p = new Permutor(limits);
 
-		List<int[]> intArrays = new LinkedList<int[]>();
+		List<int[]> intArrays = new LinkedList<>();
 
 		while (p.hasNext())
 		{

--- a/core/codegen/isagen/src/main/java/org/overturetool/cgisa/IsaGen.java
+++ b/core/codegen/isagen/src/main/java/org/overturetool/cgisa/IsaGen.java
@@ -132,7 +132,7 @@ public class IsaGen extends CodeGenBase {
         IsaTranslations isa = new IsaTranslations();
         MergeVisitor pp = isa.getMergeVisitor();
 
-        List<GeneratedModule> generated = new ArrayList<GeneratedModule>();
+        List<GeneratedModule> generated = new ArrayList<>();
 
         for (IRStatus<PIR> status : statuses) {
             generated.add(prettyPrintNode(pp, status));
@@ -163,7 +163,7 @@ public class IsaGen extends CodeGenBase {
         if (pp.hasMergeErrors()) {
             return new GeneratedModule(status.getIrNodeName(), irClass, pp.getMergeErrors(), false);
         } else if (pp.hasUnsupportedTargLangNodes()) {
-            return new GeneratedModule(status.getIrNodeName(), new HashSet<VdmNodeInfo>(), pp.getUnsupportedInTargLang(), false);
+            return new GeneratedModule(status.getIrNodeName(), new HashSet<>(), pp.getUnsupportedInTargLang(), false);
         } else {
             // Code can be generated. Ideally, should format it
             GeneratedModule generatedModule = new GeneratedModule(status.getIrNodeName(), irClass, sw.toString(), false);

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/CheckerTestBase.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/CheckerTestBase.java
@@ -39,7 +39,7 @@ public abstract class CheckerTestBase extends JavaCodeGenTestCase
 	protected static Collection<Object[]> collectTests(File root,
 			TestHandler handler)
 	{
-		Collection<Object[]> tests = new Vector<Object[]>();
+		Collection<Object[]> tests = new Vector<>();
 
 		List<File> vdmSources = TestUtils.getTestInputFiles(root);
 
@@ -132,7 +132,7 @@ public abstract class CheckerTestBase extends JavaCodeGenTestCase
 			if (Properties.recordTestResults)
 			{
 				Object vdmResult = evalVdm(file, executableTestHandler);
-				return new Result<Object>(vdmResult, new Vector<IMessage>(), new Vector<IMessage>());
+				return new Result<>(vdmResult, new Vector<>(), new Vector<>());
 			}
 
 			// Note that the classes returned in javaResult may be loaded by another class loader. This is the case for
@@ -145,14 +145,14 @@ public abstract class CheckerTestBase extends JavaCodeGenTestCase
 				Assert.fail("No Java result could be produced");
 			}
 
-			return new Result<Object>(javaResult, new Vector<IMessage>(), new Vector<IMessage>());
+			return new Result<>(javaResult, new Vector<>(), new Vector<>());
 
 		}
 
 		Assert.fail("Trying to produce result using an unsupported test handler: "
 				+ testHandler);
 
-		return new Result<Object>(null, new Vector<IMessage>(), new Vector<IMessage>());
+		return new Result<>(null, new Vector<>(), new Vector<>());
 	}
 
 	public  File[] consCpFiles()

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/ComparisonIR.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/ComparisonIR.java
@@ -395,8 +395,8 @@ public class ComparisonIR
 		}
 
 		@SuppressWarnings("unchecked")
-		List<Object> cgValuesList = new LinkedList<Object>(cgSet);
-		List<Value> vdmValuesList = new LinkedList<Value>(vdmSet.values);
+		List<Object> cgValuesList = new LinkedList<>(cgSet);
+		List<Value> vdmValuesList = new LinkedList<>(vdmSet.values);
 
 		for (int i = 0; i < cgValuesList.size(); i++)
 		{

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaCommandLineCompiler.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaCommandLineCompiler.java
@@ -157,7 +157,7 @@ public class JavaCommandLineCompiler
 
 	private static List<File> getJavaSourceFiles(File file)
 	{
-		List<File> files = new Vector<File>();
+		List<File> files = new Vector<>();
 
 		if (file.isFile())
 		{

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaExecution.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/JavaExecution.java
@@ -57,7 +57,7 @@ public class JavaExecution
 			String javaArg = JavaToolsUtils.isWindows() ? java.getAbsolutePath()
 					: "java";
 
-			List<String> commands = new Vector<String>();
+			List<String> commands = new Vector<>();
 			commands.add(javaArg);
 			commands.addAll(Arrays.asList(preArgs));
 			commands.add("-cp");

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/testhandlers/ExecutableTestHandler.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/testhandlers/ExecutableTestHandler.java
@@ -107,7 +107,7 @@ public abstract class ExecutableTestHandler extends TestHandler
 
 	public List<String> getMainClassMethods(String rootPackage)
 	{
-		return new LinkedList<String>();
+		return new LinkedList<>();
 	}
 
 	public void injectArgIntoMainClassFile(File parent, String body, String rootPackage)

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/testhandlers/TraceHandler.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/exec/util/testhandlers/TraceHandler.java
@@ -114,7 +114,7 @@ public class TraceHandler extends ExecutableSpecTestHandler
 				+ "    return acc;\n"
 				+ " }\n";
 
-		List<String> methods = new LinkedList<String>();
+		List<String> methods = new LinkedList<>();
 		methods.add(computeTestsMethod);
 
 		return methods;

--- a/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/util/TestUtils.java
+++ b/core/codegen/javagen-test/src/main/java/org/overture/codegen/tests/util/TestUtils.java
@@ -34,7 +34,7 @@ public class TestUtils
 {
 	public static List<File> getTestInputFiles(File file)
 	{
-		List<File> files = new Vector<File>();
+		List<File> files = new Vector<>();
 		for (File f : file.listFiles())
 		{
 			Collections.sort(files, new FileComparator());
@@ -63,7 +63,7 @@ public class TestUtils
 	{
 		List<File> testFiles = getTestInputFiles(new File(root));
 		
-		List<Object[]> testFilesPacked = new LinkedList<Object[]>();
+		List<Object[]> testFilesPacked = new LinkedList<>();
 		
 		for(File file : testFiles)
 		{

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGen.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGen.java
@@ -188,7 +188,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 	protected GeneratedData genVdmToTargetLang(List<IRStatus<PIR>> statuses)
 			throws AnalysisException {
 		
-		List<GeneratedModule> genModules = new LinkedList<GeneratedModule>();
+		List<GeneratedModule> genModules = new LinkedList<>();
 		
 		// Event notification
 		statuses = initialIrEvent(statuses);
@@ -233,7 +233,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 			}
 		}
 
-		List<IRStatus<SClassDeclIR>> canBeGenerated = new LinkedList<IRStatus<SClassDeclIR>>();
+		List<IRStatus<SClassDeclIR>> canBeGenerated = new LinkedList<>();
 
 		for (IRStatus<SClassDeclIR> status : classStatuses)
 		{
@@ -242,7 +242,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 				canBeGenerated.add(status);
 			} else
 			{
-				genModules.add(new GeneratedModule(status.getIrNodeName(), status.getUnsupportedInIr(), new HashSet<IrNodeInfo>(), isTestCase(status)));
+				genModules.add(new GeneratedModule(status.getIrNodeName(), status.getUnsupportedInIr(), new HashSet<>(), isTestCase(status)));
 			}
 		}
 
@@ -273,7 +273,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 		canBeGenerated = IRStatus.extract(finalIrEvent(IRStatus.extract(canBeGenerated)), SClassDeclIR.class);
 		canBeGenerated = filter(canBeGenerated, genModules, userTestCases);
 		
-		List<String> skipping = new LinkedList<String>();
+		List<String> skipping = new LinkedList<>();
 
 		MergeVisitor mergeVisitor = javaFormat.getMergeVisitor();
 		javaFormat.setFunctionValueAssistant(transSeries.getFuncValAssist());
@@ -382,7 +382,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 				quoteObserver.quoteClassesProduced(quoteClasses);
 			}
 			
-			List<GeneratedModule> modules = new LinkedList<GeneratedModule>();
+			List<GeneratedModule> modules = new LinkedList<>();
 			for (int i = 0; i < quoteClasses.size(); i++)
 			{
 				String quoteNameVdm = quoteValues.get(i);
@@ -501,8 +501,8 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 				// We can tell by analysing the VDM AST that the IR generator will produce an
 				// IR tree that the Java backend cannot code generate
 				String nodeName = getInfo().getDeclAssistant().getNodeName(node);
-				HashSet<VdmNodeInfo> nodesCopy = new HashSet<VdmNodeInfo>(v.getUnsupportedNodes());
-				statuses.add(new IRStatus<PIR>(node, nodeName, /* no IR node */null, nodesCopy));
+				HashSet<VdmNodeInfo> nodesCopy = new HashSet<>(v.getUnsupportedNodes());
+				statuses.add(new IRStatus<>(node, nodeName, /* no IR node */null, nodesCopy));
 			} else
 			{
 				super.genIrStatus(statuses, node);
@@ -522,7 +522,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 	private <T extends PIR> List<IRStatus<T>> filter(
 			List<IRStatus<T>> statuses, List<GeneratedModule> generated, List<String> userTestCases)
 	{
-		List<IRStatus<T>> filtered = new LinkedList<IRStatus<T>>();
+		List<IRStatus<T>> filtered = new LinkedList<>();
 		
 		for(IRStatus<T> status : statuses)
 		{
@@ -533,7 +533,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 			else
 			{
 				boolean isUserTestCase = userTestCases.contains(status.getIrNodeName());
-				generated.add(new GeneratedModule(status.getIrNodeName(), status.getUnsupportedInIr(), new HashSet<IrNodeInfo>(), isUserTestCase));
+				generated.add(new GeneratedModule(status.getIrNodeName(), status.getUnsupportedInIr(), new HashSet<>(), isUserTestCase));
 			}
 		}
 		
@@ -561,7 +561,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 
 		VarRenamer renamer = new VarRenamer();
 		
-		Set<Renaming> filteredRenamings = new HashSet<Renaming>();
+		Set<Renaming> filteredRenamings = new HashSet<>();
 		
 		for(Renaming r : normaliser.getRenamings())
 		{
@@ -576,7 +576,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 			renamer.rename(node, filteredRenamings);
 		}
 
-		return new LinkedList<Renaming>(filteredRenamings);
+		return new LinkedList<>(filteredRenamings);
 	}
 
 	private List<Renaming> performRenaming(
@@ -584,7 +584,7 @@ public class JavaCodeGen extends CodeGenBase implements IJavaQouteEventCoordinat
 			Map<AIdentifierStateDesignator, PDefinition> idDefs)
 			throws AnalysisException
 	{
-		List<Renaming> allRenamings = new LinkedList<Renaming>();
+		List<Renaming> allRenamings = new LinkedList<>();
 
 		VarShadowingRenameCollector renamingsCollector = new VarShadowingRenameCollector(generator.getIRInfo().getTcFactory(), idDefs);
 		VarRenamer renamer = new VarRenamer();

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenMain.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenMain.java
@@ -99,7 +99,7 @@ public class JavaCodeGenMain
 		String exp = null;
 		File outputDir = null;
 		
-		List<File> files = new LinkedList<File>();
+		List<File> files = new LinkedList<>();
 
 		Settings.release = Release.VDM_10;
 		
@@ -529,7 +529,7 @@ public class JavaCodeGenMain
 	
 	public static List<File> filterFiles(List<File> files)
 	{
-		List<File> filtered = new LinkedList<File>();
+		List<File> filtered = new LinkedList<>();
 		
 		for(File f : files)
 		{

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenUtil.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenUtil.java
@@ -275,7 +275,7 @@ public class JavaCodeGenUtil
 	 */
 	public static List<Integer> computeJavaIdentifierCorrections(String s)
 	{
-		List<Integer> correctionIndices = new LinkedList<Integer>();
+		List<Integer> correctionIndices = new LinkedList<>();
 
 		if (s == null || s.length() == 0)
 		{
@@ -304,7 +304,7 @@ public class JavaCodeGenUtil
 	{
 		List<File> files = GeneralUtils.getFilesRecursively(srcCodeFolder);
 
-		List<String> javaFilePaths = new LinkedList<String>();
+		List<String> javaFilePaths = new LinkedList<>();
 
 		for (File f : files)
 		{

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaIdentifierNormaliser.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaIdentifierNormaliser.java
@@ -24,9 +24,9 @@ public class JavaIdentifierNormaliser extends DepthFirstAnalysisAdaptor
 	public JavaIdentifierNormaliser(Set<String> allNames, ITempVarGen nameGen)
 	{
 		this.allNames = allNames;
-		this.renamingsSoFar = new HashMap<String, String>();
+		this.renamingsSoFar = new HashMap<>();
 		this.nameGen = nameGen;
-		this.renamings = new HashSet<Renaming>();
+		this.renamings = new HashSet<>();
 	}
 	
 	@Override

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaSettings.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaSettings.java
@@ -40,7 +40,7 @@ public class JavaSettings
 	public JavaSettings()
 	{
 		this.disableCloning = false;
-		this.modulesToSkip = new LinkedList<String>();
+		this.modulesToSkip = new LinkedList<>();
 		this.vdmEntryExp = null;
 		this.javaRootPackage = null;
 		this.genRecsAsInnerClasses = true;

--- a/core/codegen/javagen/src/test/java/org/overture/codegen/tests/exec/base/JavaGenTestBase.java
+++ b/core/codegen/javagen/src/test/java/org/overture/codegen/tests/exec/base/JavaGenTestBase.java
@@ -88,7 +88,7 @@ public abstract class JavaGenTestBase extends CheckerTestBase
 				((ExpressionTestHandler) testHandler).injectArgIntoMainClassFile(outputDir, s.getContent(), javaCg.getJavaSettings().getJavaRootPackage());
 			} else
 			{
-				List<File> files = new LinkedList<File>();
+				List<File> files = new LinkedList<>();
 				files.add(vdmSource);
 				
 				GeneratedData data = genData(javaCg, files);

--- a/core/codegen/javagen/src/test/java/org/overture/codegen/tests/other/IRTest.java
+++ b/core/codegen/javagen/src/test/java/org/overture/codegen/tests/other/IRTest.java
@@ -157,7 +157,7 @@ public class IRTest
 	{
 		String metaDataStr = "/*@ some meta data @*/";
 		
-		List<ClonableString> metaData = new LinkedList<ClonableString>();
+		List<ClonableString> metaData = new LinkedList<>();
 		metaData.add(new ClonableString("/*@ some meta data @*/"));
 		
 		AMetaStmIR meta = new AMetaStmIR();

--- a/core/codegen/javagen/src/test/java/org/overture/codegen/tests/other/UnsupportedJavaCodeGenTest.java
+++ b/core/codegen/javagen/src/test/java/org/overture/codegen/tests/other/UnsupportedJavaCodeGenTest.java
@@ -72,7 +72,7 @@ public class UnsupportedJavaCodeGenTest
 	@Test
 	public void test()
 	{
-		List<File> files = new LinkedList<File>();
+		List<File> files = new LinkedList<>();
 		files.add(testInputFile);
 
 		try

--- a/core/codegen/javagen/src/test/java/org/overture/codegen/tests/other/VarShadowingTest.java
+++ b/core/codegen/javagen/src/test/java/org/overture/codegen/tests/other/VarShadowingTest.java
@@ -74,7 +74,7 @@ public class VarShadowingTest
 			Value orgSpecResult = evalSpec(originalSpecTcResult.result);
 			
 			
-			List<Renaming> renamings = new LinkedList<Renaming>(new VarRenamer().computeRenamings(originalSpecTcResult.result, af, idDefs));
+			List<Renaming> renamings = new LinkedList<>(new VarRenamer().computeRenamings(originalSpecTcResult.result, af, idDefs));
 			
 			// It is very important that renamings are performed from the bottom, right to left, in order
 			// not to mess up the location of the names!!
@@ -130,7 +130,7 @@ public class VarShadowingTest
 
 	private List<VDMWarning> filter(List<VDMWarning> warnings)
 	{
-		List<VDMWarning> filtered = new LinkedList<VDMWarning>();
+		List<VDMWarning> filtered = new LinkedList<>();
 
 		for (VDMWarning w : warnings)
 		{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/DefinitionInfo.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/DefinitionInfo.java
@@ -41,7 +41,7 @@ public class DefinitionInfo
 	{
 		List<PDefinition> allLocalDefs = getAllLocalDefs();
 		
-		List<ILexNameToken> names = new LinkedList<ILexNameToken>();
+		List<ILexNameToken> names = new LinkedList<>();
 		
 		for(PDefinition def : allLocalDefs)
 		{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/NameCollector.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/NameCollector.java
@@ -13,7 +13,7 @@ public class NameCollector extends DepthFirstAnalysisAdaptor
 
 	public NameCollector()
 	{
-		this.names = new HashSet<String>();
+		this.names = new HashSet<>();
 	}
 	
 	public Set<String> namesToAvoid()

--- a/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/UnreachableStmRemover.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/UnreachableStmRemover.java
@@ -18,7 +18,7 @@ public class UnreachableStmRemover extends DepthFirstAnalysisAdaptor
 	public void caseABlockSimpleBlockStm(ABlockSimpleBlockStm node)
 			throws AnalysisException
 	{
-		List<Integer> unreachStmIndices = new LinkedList<Integer>();
+		List<Integer> unreachStmIndices = new LinkedList<>();
 		
 		boolean notreached = false;
 

--- a/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/VarShadowingRenameCollector.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/analysis/vdm/VarShadowingRenameCollector.java
@@ -95,11 +95,11 @@ public class VarShadowingRenameCollector extends DepthFirstAnalysisAdaptor
 
 		this.enclosingDef = null;
 		this.idDefs = idDefs;
-		this.localDefsInScope = new Stack<ILexNameToken>();
+		this.localDefsInScope = new Stack<>();
 		this.enclosingCounter = 0;
 
-		this.renamings = new HashSet<Renaming>();
-		this.namesToAvoid = new HashSet<String>();
+		this.renamings = new HashSet<>();
+		this.namesToAvoid = new HashSet<>();
 		this.nameGen = new TempVarNameGen();
 	}
 

--- a/core/codegen/platform/src/main/java/org/overture/codegen/analysis/violations/VdmAstAnalysis.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/analysis/violations/VdmAstAnalysis.java
@@ -50,7 +50,7 @@ public class VdmAstAnalysis
 	private Set<Violation> findViolations(List<? extends INode> nodes,
 			ViolationAnalysisApplication application) throws AnalysisException
 	{
-		Set<Violation> allViolations = new HashSet<Violation>();
+		Set<Violation> allViolations = new HashSet<>();
 
 		for (INode currentNode : nodes)
 		{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/analysis/violations/ViolationAnalysis.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/analysis/violations/ViolationAnalysis.java
@@ -34,7 +34,7 @@ public class ViolationAnalysis extends DepthFirstAnalysisAdaptor
 
 	public ViolationAnalysis(AssistantManager assistantManager)
 	{
-		this.violations = new LinkedList<Violation>();
+		this.violations = new LinkedList<>();
 		this.assistantManager = assistantManager;
 	}
 

--- a/core/codegen/platform/src/main/java/org/overture/codegen/assistant/AssistantBase.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/assistant/AssistantBase.java
@@ -51,7 +51,7 @@ public abstract class AssistantBase
 	
 	public <T extends INode> List<T> cloneNodes(List<T> list, Class<T> nodeType)
 	{
-		List<T> cloneList = new LinkedList<T>();
+		List<T> cloneList = new LinkedList<>();
 		
 		for(T e : list)
 		{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/assistant/DeclAssistantIR.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/assistant/DeclAssistantIR.java
@@ -317,7 +317,7 @@ public class DeclAssistantIR extends AssistantBase
 	public <T extends SDeclIR> List<T> getAllDecls(SClassDeclIR classDecl,
 			List<SClassDeclIR> classes, DeclStrategy<T> strategy)
 	{
-		List<T> allDecls = new LinkedList<T>();
+		List<T> allDecls = new LinkedList<>();
 
 		allDecls.addAll(strategy.getDecls(classDecl));
 
@@ -575,7 +575,7 @@ public class DeclAssistantIR extends AssistantBase
 		List<LexNameTokenWrapper> methodNames = getMethodNames(classDef);
 		Set<LexNameTokenWrapper> duplicates = findDuplicates(methodNames);
 
-		Set<ILexNameToken> overloadedMethodNames = new HashSet<ILexNameToken>();
+		Set<ILexNameToken> overloadedMethodNames = new HashSet<>();
 
 		for (LexNameTokenWrapper wrapper : methodNames)
 		{
@@ -591,8 +591,8 @@ public class DeclAssistantIR extends AssistantBase
 	private Set<LexNameTokenWrapper> findDuplicates(
 			List<LexNameTokenWrapper> nameWrappers)
 	{
-		Set<LexNameTokenWrapper> duplicates = new HashSet<LexNameTokenWrapper>();
-		Set<LexNameTokenWrapper> temp = new HashSet<LexNameTokenWrapper>();
+		Set<LexNameTokenWrapper> duplicates = new HashSet<>();
+		Set<LexNameTokenWrapper> temp = new HashSet<>();
 
 		for (LexNameTokenWrapper wrapper : nameWrappers)
 		{
@@ -608,7 +608,7 @@ public class DeclAssistantIR extends AssistantBase
 	private List<LexNameTokenWrapper> getMethodNames(
 			AClassClassDefinition classDef)
 	{
-		List<LexNameTokenWrapper> methodNames = new LinkedList<LexNameTokenWrapper>();
+		List<LexNameTokenWrapper> methodNames = new LinkedList<>();
 
 		List<PDefinition> allDefs = new LinkedList<PDefinition>();
 

--- a/core/codegen/platform/src/main/java/org/overture/codegen/assistant/LocationAssistantIR.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/assistant/LocationAssistantIR.java
@@ -122,7 +122,7 @@ public class LocationAssistantIR extends AssistantBase
 	
 	public List<IrNodeInfo> getIrNodeInfoLocationSorted(Set<IrNodeInfo> nodes)
 	{
-		List<IrNodeInfo> list = new LinkedList<IrNodeInfo>(nodes);
+		List<IrNodeInfo> list = new LinkedList<>(nodes);
 		
 		Collections.sort(list, new Comparator<IrNodeInfo>(){
 			
@@ -152,7 +152,7 @@ public class LocationAssistantIR extends AssistantBase
 	}
 	public List<VdmNodeInfo> getVdmNodeInfoLocationSorted(Set<VdmNodeInfo> nodes)
 	{
-		List<VdmNodeInfo> list = new LinkedList<VdmNodeInfo>(nodes);
+		List<VdmNodeInfo> list = new LinkedList<>(nodes);
 
 		Collections.sort(list, new Comparator<VdmNodeInfo>()
 		{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/assistant/NodeAssistantIR.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/assistant/NodeAssistantIR.java
@@ -27,7 +27,7 @@ public class NodeAssistantIR extends AssistantBase
 			return new LinkedList<>();
 		}
 
-		List<ClonableString> allMetaData = new LinkedList<ClonableString>();
+		List<ClonableString> allMetaData = new LinkedList<>();
 
 		if(prepend)
 		{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/ir/CodeGenBase.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/ir/CodeGenBase.java
@@ -498,7 +498,7 @@ abstract public class CodeGenBase implements IREventCoordinator
 				generatedModule = new GeneratedModule(status.getIrNodeName(), status.getIrNode(), mergeVisitor.getMergeErrors(), isTestCase);
 			} else if (mergeVisitor.hasUnsupportedTargLangNodes())
 			{
-				generatedModule = new GeneratedModule(status.getIrNodeName(), new HashSet<VdmNodeInfo>(), mergeVisitor.getUnsupportedInTargLang(), isTestCase);
+				generatedModule = new GeneratedModule(status.getIrNodeName(), new HashSet<>(), mergeVisitor.getUnsupportedInTargLang(), isTestCase);
 			} else
 			{
 				generatedModule = new GeneratedModule(status.getIrNodeName(), status.getIrNode(), formatCode(writer), isTestCase);
@@ -508,7 +508,7 @@ abstract public class CodeGenBase implements IREventCoordinator
 			return generatedModule;
 		} else
 		{
-			return new GeneratedModule(status.getIrNodeName(), status.getUnsupportedInIr(), new HashSet<IrNodeInfo>(), isTestCase(status));
+			return new GeneratedModule(status.getIrNodeName(), status.getUnsupportedInIr(), new HashSet<>(), isTestCase(status));
 		}
 	}
 	
@@ -540,7 +540,7 @@ abstract public class CodeGenBase implements IREventCoordinator
 				return new Generated(mergeVisitor.getMergeErrors());
 			} else if (mergeVisitor.hasUnsupportedTargLangNodes())
 			{
-				return new Generated(new HashSet<VdmNodeInfo>(), mergeVisitor.getUnsupportedInTargLang());
+				return new Generated(new HashSet<>(), mergeVisitor.getUnsupportedInTargLang());
 			} else
 			{
 				String code = writer.toString();
@@ -550,7 +550,7 @@ abstract public class CodeGenBase implements IREventCoordinator
 		} else
 		{
 
-			return new Generated(expStatus.getUnsupportedInIr(), new HashSet<IrNodeInfo>());
+			return new Generated(expStatus.getUnsupportedInIr(), new HashSet<>());
 		}
 	}
 

--- a/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRGenerator.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRGenerator.java
@@ -80,18 +80,18 @@ public class IRGenerator
 		if(node instanceof SClassDefinition)
 		{
 			SClassDeclIR classCg = node.apply(codeGenInfo.getClassVisitor(), codeGenInfo);
-			Set<VdmNodeInfo> unsupportedNodes = new HashSet<VdmNodeInfo>(codeGenInfo.getUnsupportedNodes());
+			Set<VdmNodeInfo> unsupportedNodes = new HashSet<>(codeGenInfo.getUnsupportedNodes());
 			String name = ((SClassDefinition) node).getName().getName();
 			
-			return new IRStatus<PIR>(node, name, classCg, unsupportedNodes);
+			return new IRStatus<>(node, name, classCg, unsupportedNodes);
 		}
 		else if(node instanceof AModuleModules)
 		{
 			AModuleDeclIR module = node.apply(codeGenInfo.getModuleVisitor(), codeGenInfo);
-			Set<VdmNodeInfo> unsupportedNodes = new HashSet<VdmNodeInfo>(codeGenInfo.getUnsupportedNodes());
+			Set<VdmNodeInfo> unsupportedNodes = new HashSet<>(codeGenInfo.getUnsupportedNodes());
 			String name = ((AModuleModules) node).getName().getName();
 			
-			return new IRStatus<PIR>(node, name, module, unsupportedNodes);
+			return new IRStatus<>(node, name, module, unsupportedNodes);
 		}
 		
 		return null;
@@ -109,7 +109,7 @@ public class IRGenerator
 		codeGenInfo.clearTransformationWarnings();
 
 		status.getIrNode().apply(transformation);
-		HashSet<IrNodeInfo> transformationWarnings = new HashSet<IrNodeInfo>(codeGenInfo.getTransformationWarnings());
+		HashSet<IrNodeInfo> transformationWarnings = new HashSet<>(codeGenInfo.getTransformationWarnings());
 
 		status.addTransformationWarnings(transformationWarnings);
 	}
@@ -126,7 +126,7 @@ public class IRGenerator
 		codeGenInfo.clearTransformationWarnings();
 
 		status.getIrNode().apply(trans);
-		HashSet<IrNodeInfo> transformationWarnings = new HashSet<IrNodeInfo>(codeGenInfo.getTransformationWarnings());
+		HashSet<IrNodeInfo> transformationWarnings = new HashSet<>(codeGenInfo.getTransformationWarnings());
 		status.addTransformationWarnings(transformationWarnings);
 		status.setIrNode(trans.getResult());
 	}
@@ -136,7 +136,7 @@ public class IRGenerator
 		codeGenInfo.clearNodes();
 
 		SExpIR expCg = exp.apply(codeGenInfo.getExpVisitor(), codeGenInfo);
-		Set<VdmNodeInfo> unsupportedNodes = new HashSet<VdmNodeInfo>(codeGenInfo.getUnsupportedNodes());
+		Set<VdmNodeInfo> unsupportedNodes = new HashSet<>(codeGenInfo.getUnsupportedNodes());
 
 		return new IRStatus<SExpIR>(exp, "expression",expCg, unsupportedNodes);
 	}

--- a/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRInfo.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRInfo.java
@@ -110,9 +110,9 @@ public class IRInfo
 		this.visitorManager = new VisitorManager();
 		this.assistantManager = new AssistantManager();
 		this.tcFactory = new TypeCheckerAssistantFactory();
-		this.quoteVaues = new LinkedList<String>();
-		this.unsupportedNodes = new HashSet<VdmNodeInfo>();
-		this.transformationWarnings = new HashSet<IrNodeInfo>();
+		this.quoteVaues = new LinkedList<>();
+		this.unsupportedNodes = new HashSet<>();
+		this.transformationWarnings = new HashSet<>();
 		this.tempVarNameGen = new TempVarNameGen();
 
 		this.settings = new IRSettings();

--- a/core/codegen/platform/src/main/java/org/overture/codegen/ir/IROperatorLookup.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/ir/IROperatorLookup.java
@@ -97,7 +97,7 @@ public class IROperatorLookup
 
 	public IROperatorLookup()
 	{
-		this.lookup = new HashMap<Class<? extends SExpIR>, IROperatorInfo>();
+		this.lookup = new HashMap<>();
 
 		lookup.put(APlusNumericBinaryExpIR.class, new IROperatorInfo(PLUS, "+"));
 		lookup.put(ASubtractNumericBinaryExpIR.class, new IROperatorInfo(SUB, "-"));

--- a/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRStatus.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/ir/IRStatus.java
@@ -41,7 +41,7 @@ public final class IRStatus<T extends PIR>
 	{
 		this.vdmNode = vdmNode;
 		this.unsupportedInIr = unsupportedInIr;
-		this.transformationWarnings = new HashSet<IrNodeInfo>();
+		this.transformationWarnings = new HashSet<>();
 	}
 
 	public IRStatus(INode vdmNode, String nodeName, T node, Set<VdmNodeInfo> unsupportedNodes)
@@ -139,7 +139,7 @@ public final class IRStatus<T extends PIR>
 	public static <T extends PIR> List<IRStatus<T>> extract(
 			List<IRStatus<PIR>> inputStatuses, Class<T> type)
 	{
-		List<IRStatus<T>> outputStatuses = new LinkedList<IRStatus<T>>();
+		List<IRStatus<T>> outputStatuses = new LinkedList<>();
 
 		for (IRStatus<PIR> status : inputStatuses)
 		{
@@ -162,12 +162,12 @@ public final class IRStatus<T extends PIR>
 		Set<VdmNodeInfo> unsupportedInIr = inputStatus.getUnsupportedInIr();
 		Set<IrNodeInfo> warnings = inputStatus.getTransformationWarnings();
 
-		return new IRStatus<PIR>(vdmNode, name, node, unsupportedInIr, warnings);
+		return new IRStatus<>(vdmNode, name, node, unsupportedInIr, warnings);
 	}
 	
 	public static <T extends PIR> List<IRStatus<PIR>> extract(List<IRStatus<T>> inputStatuses)
 	{
-		List<IRStatus<PIR>> outputStatuses = new LinkedList<IRStatus<PIR>>();
+		List<IRStatus<PIR>> outputStatuses = new LinkedList<>();
 		
 		for(IRStatus<T> status : inputStatuses)
 		{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/ir/TempVarNameGen.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/ir/TempVarNameGen.java
@@ -32,7 +32,7 @@ public class TempVarNameGen implements ITempVarGen
 	public TempVarNameGen()
 	{
 		super();
-		this.counters = new HashMap<String, Integer>();
+		this.counters = new HashMap<>();
 	}
 	
 	@Override

--- a/core/codegen/platform/src/main/java/org/overture/codegen/merging/MergeVisitor.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/merging/MergeVisitor.java
@@ -64,10 +64,10 @@ public class MergeVisitor extends QuestionAdaptor<StringWriter> implements
 			TemplateCallable[] templateCallables)
 	{
 		this.templates = templateManager;
-		this.nodeContexts = new Stack<MergeContext>();
+		this.nodeContexts = new Stack<>();
 		this.templateCallables = addDefaults(templateCallables);
-		this.mergeErrors = new LinkedList<Exception>();
-		this.unsupportedInTargLang = new HashSet<IrNodeInfo>();
+		this.mergeErrors = new LinkedList<>();
+		this.unsupportedInTargLang = new HashSet<>();
 	}
 
 	/**
@@ -116,8 +116,8 @@ public class MergeVisitor extends QuestionAdaptor<StringWriter> implements
 	public void init()
 	{
 		// Avoid clearing the data structures if others are using them
-		mergeErrors = new LinkedList<Exception>();
-		unsupportedInTargLang = new HashSet<IrNodeInfo>();
+		mergeErrors = new LinkedList<>();
+		unsupportedInTargLang = new HashSet<>();
 	}
 
 	private void initCodeGenContext(INode node,

--- a/core/codegen/platform/src/main/java/org/overture/codegen/merging/TemplateManager.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/merging/TemplateManager.java
@@ -46,7 +46,7 @@ public class TemplateManager
 	/**
 	 * cache
 	 */
-	final protected HashMap<Class<? extends INode>, Template> cache = new HashMap<Class<? extends INode>, Template>();
+	final protected HashMap<Class<? extends INode>, Template> cache = new HashMap<>();
 
 	protected String root;
 

--- a/core/codegen/platform/src/main/java/org/overture/codegen/traces/StoreAssistant.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/traces/StoreAssistant.java
@@ -27,7 +27,7 @@ public class StoreAssistant
 	{
 		super();
 		this.tracePrefixes = tracePrefixes;
-		this.idConstNameMap = new HashMap<String, String>();
+		this.idConstNameMap = new HashMap<>();
 		this.transAssistant = transAssistant;
 	}
 	

--- a/core/codegen/platform/src/main/java/org/overture/codegen/trans/patterns/PatternTrans.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/trans/patterns/PatternTrans.java
@@ -421,7 +421,7 @@ public class PatternTrans extends DepthFirstAnalysisAdaptor
 			}
 		}
 
-		List<PatternInfo> patternInfo = new LinkedList<PatternInfo>();
+		List<PatternInfo> patternInfo = new LinkedList<>();
 		patternInfo.add(declInfo);
 
 		ABlockStmIR replacementBlock = new ABlockStmIR();
@@ -538,7 +538,7 @@ public class PatternTrans extends DepthFirstAnalysisAdaptor
 	
 	private List<DeclBlockPair> consPatternHandlingBlocksSeparate(List<AVarDeclIR> decls, List<PatternInfo> patternInfo)
 	{
-		List<DeclBlockPair> blocks = new LinkedList<DeclBlockPair>();
+		List<DeclBlockPair> blocks = new LinkedList<>();
 		
 		for (int i = 0; i < patternInfo.size(); i++)
 		{
@@ -1127,7 +1127,7 @@ public class PatternTrans extends DepthFirstAnalysisAdaptor
 
 	public List<PatternInfo> extractFromLocalDefs(List<AVarDeclIR> localDefs)
 	{
-		List<PatternInfo> patternInfo = new LinkedList<PatternInfo>();
+		List<PatternInfo> patternInfo = new LinkedList<>();
 
 		for (AVarDeclIR decl : localDefs)
 		{
@@ -1150,7 +1150,7 @@ public class PatternTrans extends DepthFirstAnalysisAdaptor
 	public List<PatternInfo> extractFromParams(
 			List<AFormalParamLocalParamIR> params)
 	{
-		List<PatternInfo> patternInfo = new LinkedList<PatternInfo>();
+		List<PatternInfo> patternInfo = new LinkedList<>();
 
 		for (AFormalParamLocalParamIR param : params)
 		{
@@ -1166,7 +1166,7 @@ public class PatternTrans extends DepthFirstAnalysisAdaptor
 	public List<PatternInfo> extractFromCases(List<ACaseAltStmStmIR> cases,
 			SExpIR exp)
 	{
-		List<PatternInfo> patternInfo = new LinkedList<PatternInfo>();
+		List<PatternInfo> patternInfo = new LinkedList<>();
 
 		for (ACaseAltStmStmIR alt : cases)
 		{

--- a/core/codegen/platform/src/main/java/org/overture/codegen/trans/patterns/PatternVarPrefixes.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/trans/patterns/PatternVarPrefixes.java
@@ -47,7 +47,7 @@ public class PatternVarPrefixes
 
 	private void setupNameLookup()
 	{
-		this.patternNamePrefixes = new HashMap<Class<? extends SPatternIR>, String>();
+		this.patternNamePrefixes = new HashMap<>();
 
 		this.patternNamePrefixes.put(AIgnorePatternIR.class, getIgnorePatternPrefix());
 		this.patternNamePrefixes.put(ABoolPatternIR.class, getBoolPatternPrefix());

--- a/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralCodeGenUtils.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralCodeGenUtils.java
@@ -436,12 +436,12 @@ public class GeneralCodeGenUtils
 	{
 		if(userInput == null)
 		{
-			return new LinkedList<String>();
+			return new LinkedList<>();
 		}
 		
 		String[] split = userInput.split(";");
 
-		List<String> classesToSkip = new LinkedList<String>();
+		List<String> classesToSkip = new LinkedList<>();
 		
 		for(String element : split)
 		{
@@ -513,7 +513,7 @@ public class GeneralCodeGenUtils
 	
 	public static List<Violation> asSortedList(Set<Violation> violations)
 	{
-		LinkedList<Violation> list = new LinkedList<Violation>(violations);
+		LinkedList<Violation> list = new LinkedList<>(violations);
 		Collections.sort(list);
 
 		return list;

--- a/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralUtils.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/utils/GeneralUtils.java
@@ -105,7 +105,7 @@ public class GeneralUtils
 	{
 		File[] listOfFiles = folder.listFiles();
 
-		List<File> fileList = new LinkedList<File>();
+		List<File> fileList = new LinkedList<>();
 
 		if (listOfFiles == null || listOfFiles.length == 0)
 		{
@@ -125,7 +125,7 @@ public class GeneralUtils
 
 	public static void deleteFolderContents(File folder, boolean removeFolders)
 	{
-		deleteFolderContents(folder, new ArrayList<String>(), removeFolders);
+		deleteFolderContents(folder, new ArrayList<>(), removeFolders);
 	}
 
 	public static void deleteFolderContents(File folder,
@@ -178,7 +178,7 @@ public class GeneralUtils
 	{
 		File[] listOfFiles = folder.listFiles();
 		
-		List<File> fileList = new LinkedList<File>();
+		List<File> fileList = new LinkedList<>();
 
 		if(listOfFiles == null || listOfFiles.length == 0)
 			return fileList;

--- a/core/codegen/platform/src/main/java/org/overture/codegen/utils/Generated.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/utils/Generated.java
@@ -44,23 +44,23 @@ public class Generated
 		this.content = content;
 		this.unsupportedInIr = unsupportedInIr;
 		this.unsupportedInTargLang = unsupportedInTargLang;
-		this.transformationWarnings = new HashSet<IrNodeInfo>();
+		this.transformationWarnings = new HashSet<>();
 		this.mergeErrors = mergeErrors;
 	}
 
 	public Generated(String content)
 	{
-		this(content, new HashSet<VdmNodeInfo>(), new HashSet<IrNodeInfo>(),new LinkedList<Exception>());
+		this(content, new HashSet<>(), new HashSet<>(), new LinkedList<>());
 	}
 
 	public Generated(Set<VdmNodeInfo> unsupportedNodes, Set<IrNodeInfo> unsupportedInTargLang)
 	{
-		this(null, unsupportedNodes, unsupportedInTargLang,new LinkedList<Exception>());
+		this(null, unsupportedNodes, unsupportedInTargLang, new LinkedList<>());
 	}
 
 	public Generated(List<Exception> mergeErrrors)
 	{
-		this(null, new HashSet<VdmNodeInfo>(), new HashSet<IrNodeInfo>(),mergeErrrors);
+		this(null, new HashSet<>(), new HashSet<>(),mergeErrrors);
 	}
 
 	public String getContent()

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/JmlAnnotationHelper.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/JmlAnnotationHelper.java
@@ -187,7 +187,7 @@ public class JmlAnnotationHelper
 
 	public List<ClonableString> consMetaData(String str)
 	{
-		List<ClonableString> inv = new LinkedList<ClonableString>();
+		List<ClonableString> inv = new LinkedList<>();
 
 		inv.add(new ClonableString(str));
 

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/JmlGenMain.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/JmlGenMain.java
@@ -41,7 +41,7 @@ public class JmlGenMain
 
 		List<String> listArgs = Arrays.asList(args);
 
-		List<File> files = new LinkedList<File>();
+		List<File> files = new LinkedList<>();
 		
 		File outputDir = null;
 

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/JmlGenUtil.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/JmlGenUtil.java
@@ -140,7 +140,7 @@ public class JmlGenUtil
 	
 	public List<String> getRecFieldNames(ARecordDeclIR r)
 	{
-		List<String> args = new LinkedList<String>();
+		List<String> args = new LinkedList<>();
 		
 		for(AFieldDeclIR f : r.getFields())
 		{
@@ -219,7 +219,7 @@ public class JmlGenUtil
 	 */
 	public List<IRStatus<PIR>> makeRecsOuterClasses(List<IRStatus<PIR>> ast, RecClassInfo recInfo)
 	{
-		List<IRStatus<PIR>> extraClasses = new LinkedList<IRStatus<PIR>>();
+		List<IRStatus<PIR>> extraClasses = new LinkedList<>();
 
 		for (IRStatus<ADefaultClassDeclIR> status : IRStatus.extract(ast, ADefaultClassDeclIR.class))
 		{
@@ -310,7 +310,7 @@ public class JmlGenUtil
 				imports.add(new ClonableString(JavaCodeGen.RUNTIME_IMPORT));
 				recClass.setDependencies(imports);
 
-				extraClasses.add(new IRStatus<PIR>(recClass.getSourceNode().getVdmNode(), recClass.getName(), recClass, new HashSet<VdmNodeInfo>()));
+				extraClasses.add(new IRStatus<>(recClass.getSourceNode().getVdmNode(), recClass.getName(), recClass, new HashSet<>()));
 			}
 		}
 

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/JmlGenerator.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/JmlGenerator.java
@@ -286,7 +286,7 @@ public class JmlGenerator implements IREventObserver, IJavaQuoteEventObserver
 		 */
 		RecClassInfo recInfo = makeRecStateAccessorBased(ast);
 		
-		List<IRStatus<PIR>> newAst = new LinkedList<IRStatus<PIR>>(ast);
+		List<IRStatus<PIR>> newAst = new LinkedList<>(ast);
 
 		// To circumvent a problem with OpenJML. See documentation of makeRecsOuterClasses
 		newAst.addAll(util.makeRecsOuterClasses(ast, recInfo));
@@ -560,7 +560,7 @@ public class JmlGenerator implements IREventObserver, IJavaQuoteEventObserver
 		{
 			AMethodDeclIR cond = (AMethodDeclIR) decl;
 
-			List<String> fieldNames = new LinkedList<String>();
+			List<String> fieldNames = new LinkedList<>();
 
 			// The arguments of a function or an operation are passed to the pre/post condition
 			int i;

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/data/StateDesInfo.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/data/StateDesInfo.java
@@ -39,7 +39,7 @@ public class StateDesInfo
 	
 	public Pair<List<AIdentifierVarExpIR>, List<AVarDeclIR>> remove(SStmIR key)
 	{
-		return new Pair<List<AIdentifierVarExpIR>, List<AVarDeclIR>>(stateDesVars.remove(key), stateDesDecls.remove(key)); 
+		return new Pair<>(stateDesVars.remove(key), stateDesDecls.remove(key)); 
 	}
 	
 	public void register(SStmIR key, List<AIdentifierVarExpIR> vars, List<AVarDeclIR> decls)

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/predgen/info/LeafTypeInfo.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/predgen/info/LeafTypeInfo.java
@@ -85,7 +85,7 @@ public class LeafTypeInfo extends AbstractTypeInfo
 	@Override
 	public List<LeafTypeInfo> getLeafTypesRecursively()
 	{
-		List<LeafTypeInfo> types = new LinkedList<LeafTypeInfo>();
+		List<LeafTypeInfo> types = new LinkedList<>();
 		types.add(this);
 		
 		return types;

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/predgen/info/NamedTypeInvDepCalculator.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/predgen/info/NamedTypeInvDepCalculator.java
@@ -32,7 +32,7 @@ public class NamedTypeInvDepCalculator extends DepthFirstAnalysisAdaptor
 	{
 		super();
 		this.info = info;
-		this.typeInfoList = new LinkedList<NamedTypeInfo>();
+		this.typeInfoList = new LinkedList<>();
 	}
 
 	public List<NamedTypeInfo> getTypeDataList()

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/util/NameGen.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/util/NameGen.java
@@ -21,7 +21,7 @@ public class NameGen
 	
 	public NameGen()
 	{
-		this.toAvoid = new HashSet<String>();
+		this.toAvoid = new HashSet<>();
 	}
 	
 	public NameGen(INode vdmNode)

--- a/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/AnnotationTestsBase.java
+++ b/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/AnnotationTestsBase.java
@@ -174,7 +174,7 @@ abstract public class AnnotationTestsBase
 	public static List<ADefaultClassDeclIR> getClasses(String fileName)
 			throws AnalysisException
 	{
-		List<File> files = new LinkedList<File>();
+		List<File> files = new LinkedList<>();
 		files.add(new File(TEST_RES_STATIC_ANALYSIS_ROOT + fileName));
 
 		

--- a/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/JmlGenTestBase.java
+++ b/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/JmlGenTestBase.java
@@ -72,7 +72,7 @@ abstract public class JmlGenTestBase
 	
 	public String[] getJmlGenMainProcessArgs(File outputFolder)
 	{
-		List<String> javaCgArgs = new LinkedList<String>();
+		List<String> javaCgArgs = new LinkedList<>();
 		
 		javaCgArgs.add(inputFile.getAbsolutePath());
 		if(VERBOSE)

--- a/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/TypeDependencyTests.java
+++ b/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/TypeDependencyTests.java
@@ -30,7 +30,7 @@ public class TypeDependencyTests extends AnnotationTestsBase
 	{
 		try
 		{
-			List<File> files = new LinkedList<File>();
+			List<File> files = new LinkedList<>();
 
 			files.add(new File(TEST_RES_TYPE_DEP_ROOT + filename));
 

--- a/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/exec/JmlSlJavaGenTestBase.java
+++ b/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/exec/JmlSlJavaGenTestBase.java
@@ -86,7 +86,7 @@ public abstract class JmlSlJavaGenTestBase extends CheckerTestBase
 
 	public void genJavaSources(File vdmSource)
 	{
-		List<File> files = new LinkedList<File>();
+		List<File> files = new LinkedList<>();
 		files.add(vdmSource);
 
 		TypeCheckResult<List<AModuleModules>> tcResult = checkTcResult(TypeCheckerUtil.typeCheckSl(files));

--- a/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/util/TestUtil.java
+++ b/core/codegen/vdm2jml/src/test/java/org/overture/vdm2jml/tests/util/TestUtil.java
@@ -17,7 +17,7 @@ public class TestUtil
 	{
 		List<File> files = GeneralUtils.getFiles(folder);
 		
-		LinkedList<File> javaFiles = new LinkedList<File>();
+		LinkedList<File> javaFiles = new LinkedList<>();
 		
 		for(File f : files)
 		{
@@ -39,7 +39,7 @@ public class TestUtil
 		String quotesDir = File.separatorChar + JavaCodeGen.JAVA_QUOTES_PACKAGE
 				+ File.separatorChar;
 		
-		List<File> filesToStore = new LinkedList<File>();
+		List<File> filesToStore = new LinkedList<>();
 	
 		for (File file : files)
 		{
@@ -58,7 +58,7 @@ public class TestUtil
 	
 	public static Collection<Object[]> collectVdmslFiles(List<File> files)
 	{
-		List<Object[]> testInputFiles = new LinkedList<Object[]>();
+		List<Object[]> testInputFiles = new LinkedList<>();
 
 		for (File f : files)
 		{

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceInterpreter.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceInterpreter.java
@@ -318,7 +318,7 @@ public class TraceInterpreter
 				}
 			} catch (Exception e)
 			{
-				result = new Vector<Object>();
+				result = new Vector<>();
 				result.add(e);
 				verdict = Verdict.FAILED;
 				result.add(verdict);
@@ -479,7 +479,7 @@ public class TraceInterpreter
 			result = interpreter.runOneTrace(mtd, test, false);
 		} catch (Exception e)
 		{
-			result = new Vector<Object>();
+			result = new Vector<>();
 			result.add(e.getMessage());
 			result.add(e);
 			result.add(Verdict.ERROR);

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceRunnerMain.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceRunnerMain.java
@@ -121,7 +121,7 @@ public class TraceRunnerMain implements IProgressMonitor
 		String ideKey = null;
 		Settings.dialect = null;
 		String moduleName = null;
-		List<File> files = new Vector<File>();
+		List<File> files = new Vector<>();
 		List<String> largs = Arrays.asList(args);
 		VDMJ controller = null;
 		boolean warnings = true;

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/xml/XMLParser.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/server/xml/XMLParser.java
@@ -299,7 +299,7 @@ public class XMLParser
 		checkFor(Token.TAG);
 
 		Properties attr = null;
-		List<XMLNode> children = new Vector<XMLNode>();
+		List<XMLNode> children = new Vector<>();
 
 		if (token == Token.TAG)
 		{

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/CtHelper.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/CtHelper.java
@@ -97,7 +97,7 @@ public class CtHelper
 						+ data.reduction.getReductionType().toString() + ","
 						+ data.reduction.getSeed() + "}" };
 		
-		List<String> argArray = new Vector<String>(Arrays.asList(args));
+		List<String> argArray = new Vector<>(Arrays.asList(args));
 		
 		
 		for (Iterator<File> itr = data.specFiles.iterator(); itr.hasNext();)

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/TraceResult.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/TraceResult.java
@@ -27,7 +27,7 @@ import java.util.Vector;
 public class TraceResult
 {
 	public String traceName;
-	public List<TraceTest> tests = new Vector<TraceTest>();
+	public List<TraceTest> tests = new Vector<>();
 
 	@Override
 	public String toString()

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/TraceResultReader.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/utils/TraceResultReader.java
@@ -48,7 +48,7 @@ public class TraceResultReader
 	public List<TraceResult> read(File file) throws SAXException, IOException,
 			ParserConfigurationException, XPathExpressionException
 	{
-		List<TraceResult> results = new Vector<TraceResult>();
+		List<TraceResult> results = new Vector<>();
 
 		DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 		factory.setNamespaceAware(true);

--- a/core/combinatorialtesting/ctruntime/src/test/java/org/overture/ct/ctruntime/tests/CtRandomReductionSlTestCase.java
+++ b/core/combinatorialtesting/ctruntime/src/test/java/org/overture/ct/ctruntime/tests/CtRandomReductionSlTestCase.java
@@ -74,7 +74,7 @@ public class CtRandomReductionSlTestCase extends CtTestCaseBase
 		testReduction.add(new ReductionTestData("PaperCaseStudy", new TraceReductionInfo(0.01F, TraceReductionType.SHAPES_VARNAMES, SEED),3));
 		testReduction.add(new ReductionTestData("PaperCaseStudy", new TraceReductionInfo(0.01F, TraceReductionType.SHAPES_VARVALUES, SEED),21));
 
-		Collection<Object[]> tests = new Vector<Object[]>();
+		Collection<Object[]> tests = new Vector<>();
 		
 
 		File root = new File(RESOURCES);

--- a/core/combinatorialtesting/ctruntime/src/test/java/org/overture/ct/ctruntime/tests/util/TestSourceFinder.java
+++ b/core/combinatorialtesting/ctruntime/src/test/java/org/overture/ct/ctruntime/tests/util/TestSourceFinder.java
@@ -46,7 +46,7 @@ public class TestSourceFinder
 		File testRoot = getFile(testRootPath);
 
 		// TestSuite suite = new TestSourceFinder(name);
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -55,7 +55,7 @@ public class TestSourceFinder
 				if (file.isDirectory() && !file.getName().startsWith("."))
 				{
 					//tests.addAll(createCompleteFile(dialect, name, file, testRoot, extensions));
-					List<File> specFiles = new Vector<File>();
+					List<File> specFiles = new Vector<>();
 					for (File f : file.listFiles())
 					{
 						if(isNotAcceptedFile(f, Arrays.asList(extensions)))
@@ -114,7 +114,7 @@ public class TestSourceFinder
 	{
 		File testRoot = getFile(testRootPath.replace('/', File.separatorChar));
 
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -153,7 +153,7 @@ public class TestSourceFinder
 		File testRoot = getFile(testRootPath);
 
 		// TestSuite suite = new TestSourceFinder(name);
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -169,7 +169,7 @@ public class TestSourceFinder
 	private static Collection<Object[]> createCompleteFile(Dialect dialect,
 			String suite, File file, File testRoot, String... extensions)
 	{
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (file.getName().startsWith(".")
 				|| !isNotAcceptedFile(file, Arrays.asList(extensions)))
@@ -222,7 +222,7 @@ public class TestSourceFinder
 	private static Collection<Object[]> createDirectory(Dialect dialect,
 			String suite, File file, String... extensions)
 	{
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (file.getName().startsWith(".")
 				|| !isNotAcceptedFile(file, Arrays.asList(extensions)))
@@ -266,7 +266,7 @@ public class TestSourceFinder
 	{
 		File testRoot = getFile(testRootPath);
 
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -297,7 +297,7 @@ public class TestSourceFinder
 
 	protected static List<String> readFile(File file) throws IOException
 	{
-		List<String> lines = new Vector<String>();
+		List<String> lines = new Vector<>();
 		BufferedReader reader = null;
 
 		try

--- a/core/combinatorialtesting/ctutils/src/main/java/org/overture/ct/utils/TraceTestResult.java
+++ b/core/combinatorialtesting/ctutils/src/main/java/org/overture/ct/utils/TraceTestResult.java
@@ -26,8 +26,8 @@ import java.util.Vector;
 
 public class TraceTestResult extends TraceTestStatus
 {
-	private List<String> arguments = new Vector<String>();
-	private List<String> results = new Vector<String>();
+	private List<String> arguments = new Vector<>();
+	private List<String> results = new Vector<>();
 
 	/**
 	 * @param results

--- a/core/combinatorialtesting/ctutils/src/main/java/org/overture/ct/utils/TraceXmlWrapper.java
+++ b/core/combinatorialtesting/ctutils/src/main/java/org/overture/ct/utils/TraceXmlWrapper.java
@@ -62,7 +62,7 @@ public class TraceXmlWrapper
 		// openElements.push(ROOT_TAG);
 	}
 
-	Stack<String> openElements = new Stack<String>();
+	Stack<String> openElements = new Stack<>();
 
 	public void StartClass(String className) throws IOException
 	{

--- a/core/interpreter/src/main/java/CSV.java
+++ b/core/interpreter/src/main/java/CSV.java
@@ -186,7 +186,7 @@ public class CSV extends IO implements Serializable
 		BufferedReader bufRdr = new BufferedReader(new FileReader(file));
 		String line = null;
 		int lineIndex = 0;
-		List<String> cells = new Vector<String>();
+		List<String> cells = new Vector<>();
 
 		if (index < 1)
 		{

--- a/core/interpreter/src/main/java/TestRunner.java
+++ b/core/interpreter/src/main/java/TestRunner.java
@@ -15,7 +15,7 @@ public class TestRunner
 {
 	public static Value collectTests(Value obj)
 	{
-		List<String> tests = new Vector<String>();
+		List<String> tests = new Vector<>();
 		ObjectValue instance = (ObjectValue) obj;
 
 		if (ClassInterpreter.getInstance() instanceof ClassInterpreter)

--- a/core/interpreter/src/main/java/TestSuite.java
+++ b/core/interpreter/src/main/java/TestSuite.java
@@ -20,7 +20,7 @@ public class TestSuite
 {
 	public static Value getTestMethodNamed(Value test)
 	{
-		List<String> tests = new Vector<String>();
+		List<String> tests = new Vector<>();
 		ObjectValue instance = (ObjectValue) test;
 
 		for (NameValuePair p : instance.members.asList())
@@ -45,7 +45,7 @@ public class TestSuite
 
 	public static Value createTests(Value test) throws Exception
 	{
-		List<String> tests = new Vector<String>();
+		List<String> tests = new Vector<>();
 		ValueList vals = new ValueList();
 		ObjectValue instance = (ObjectValue) test;
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/VDMJ.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/VDMJ.java
@@ -82,8 +82,8 @@ abstract public class VDMJ
 	@SuppressWarnings("unchecked")
 	public static void main(String[] args)
 	{
-		List<File> filenames = new Vector<File>();
-		List<File> pathnames = new Vector<File>();
+		List<File> filenames = new Vector<>();
+		List<File> pathnames = new Vector<>();
 		List<String> largs = Arrays.asList(args);
 		VDMJ controller = null;
 		Dialect dialect = Dialect.VDM_SL;

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/definition/AExplicitFunctionDefinitionAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/definition/AExplicitFunctionDefinitionAssistantInterpreter.java
@@ -34,7 +34,7 @@ public class AExplicitFunctionDefinitionAssistantInterpreter extends
 
 		if (state.polyfuncs == null)
 		{
-			state.polyfuncs = new HashMap<List<PType>, FunctionValue>();
+			state.polyfuncs = new HashMap<>();
 		} else
 		{
 			// We always return the same function value for a polymorph

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/definition/SClassDefinitionAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/definition/SClassDefinitionAssistantInterpreter.java
@@ -151,7 +151,7 @@ public class SClassDefinitionAssistantInterpreter extends
 						+ node.getName(), ctxt);
 			}
 
-			return af.createSClassDefinitionAssistant().makeNewInstance(node, ctorDefinition, argvals, ctxt, new HashMap<ILexNameToken, ObjectValue>(), false);
+			return af.createSClassDefinitionAssistant().makeNewInstance(node, ctorDefinition, argvals, ctxt, new HashMap<>(), false);
 			//return af.createAClassClassDefinitionAssistant().newInstance((AClassClassDefinition) node, ctorDefinition, argvals, ctxt);
 		} else if (node instanceof ACpuClassDefinition)
 		{
@@ -175,7 +175,7 @@ public class SClassDefinitionAssistantInterpreter extends
 		setStaticDefinitions(node, ctxt.getGlobal()); // When static member := new X()
 		setStaticValues(node, ctxt.getGlobal()); // When static member := new X()
 
-		List<ObjectValue> inherited = new Vector<ObjectValue>();
+		List<ObjectValue> inherited = new Vector<>();
 		NameValuePairMap members = new NameValuePairMap();
 
 		for (SClassDefinition sdef : node.getSuperDefs())

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/module/AModuleModulesAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/module/AModuleModulesAssistantInterpreter.java
@@ -149,7 +149,7 @@ public class AModuleModulesAssistantInterpreter extends
 			StateContext initialContext)
 	{
 
-		Set<ContextException> trouble = new HashSet<ContextException>();
+		Set<ContextException> trouble = new HashSet<>();
 
 		for (PDefinition d : m.getImportdefs())
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/module/ModuleListAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/module/ModuleListAssistantInterpreter.java
@@ -46,7 +46,7 @@ public class ModuleListAssistantInterpreter
 
 		do
 		{
-			problems = new HashSet<ContextException>();
+			problems = new HashSet<>();
 
 			for (AModuleModules m : modules)
 			{

--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/pattern/AMapPatternMapletAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/pattern/AMapPatternMapletAssistantInterpreter.java
@@ -30,7 +30,7 @@ public class AMapPatternMapletAssistantInterpreter implements IAstAssistant
 	{
 		List<NameValuePairList> flist = af.createPPatternAssistant().getAllNamedValues(p.getFrom(), maplet.getKey(), ctxt);
 		List<NameValuePairList> tlist = af.createPPatternAssistant().getAllNamedValues(p.getTo(), maplet.getValue(), ctxt);
-		List<NameValuePairList> results = new Vector<NameValuePairList>();
+		List<NameValuePairList> results = new Vector<>();
 
 		for (NameValuePairList f : flist)
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/commands/DebuggerReader.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/commands/DebuggerReader.java
@@ -89,7 +89,7 @@ public class DebuggerReader extends CommandReader
 				throw new InternalException(52, "Cannot set default name at breakpoint");
 			}
 
-			ExitStatus status = super.run(new Vector<File>());
+			ExitStatus status = super.run(new Vector<>());
 
 			return status;
 		}

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPExecProcesser.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPExecProcesser.java
@@ -44,7 +44,7 @@ public class DBGPExecProcesser
 
 		Interpreter i = interpreter;
 		final DBGPReader d = reader;
-		List<File> fileList = new Vector<File>(i.getSourceFiles());
+		List<File> fileList = new Vector<>(i.getSourceFiles());
 		final Writer result = new StringWriter();
 		final Reader input = new StringReader(command);
 		// System.out.println("Command session started in " + new File(".").getAbsolutePath());

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReader.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReader.java
@@ -135,7 +135,7 @@ public class DBGPReader
 
 	protected static final int SOURCE_LINES = 5;
 
-	protected static List<DBGPReader> connectecReaders = new Vector<DBGPReader>();
+	protected static List<DBGPReader> connectecReaders = new Vector<>();
 
 	@SuppressWarnings("unchecked")
 	public static void main(String[] args)
@@ -147,7 +147,7 @@ public class DBGPReader
 		String ideKey = null;
 		Settings.dialect = null;
 		String expression = null;
-		List<File> files = new Vector<File>();
+		List<File> files = new Vector<>();
 		List<String> largs = Arrays.asList(args);
 		VDMJ controller = null;
 		boolean warnings = true;
@@ -1089,7 +1089,7 @@ public class DBGPReader
 	{
 		// "<type> [<options>] [-- <base64 args>]"
 
-		List<DBGPOption> options = new Vector<DBGPOption>();
+		List<DBGPOption> options = new Vector<>();
 		String args = null;
 		boolean doneOpts = false;
 		boolean gotXID = false;

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReaderV2.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReaderV2.java
@@ -129,7 +129,7 @@ public class DBGPReaderV2 extends DBGPReader implements Serializable
 	/**
 	 * Map containing Values accessible from the client by a key. Should be emptied at resume
 	 */
-	private Map<Integer, Value> debugValueMap = new Hashtable<Integer, Value>();
+	private Map<Integer, Value> debugValueMap = new Hashtable<>();
 	/**
 	 * Debug key counter for the client
 	 */
@@ -150,7 +150,7 @@ public class DBGPReaderV2 extends DBGPReader implements Serializable
 		String ideKey = null;
 		Settings.dialect = null;
 		String expression = null;
-		List<File> files = new Vector<File>();
+		List<File> files = new Vector<>();
 		List<String> largs = Arrays.asList(args);
 		VDMJ controller = null;
 		boolean warnings = true;

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/RemoteInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/RemoteInterpreter.java
@@ -148,7 +148,7 @@ public class RemoteInterpreter
 
 	public List<String> getModules() throws Exception
 	{
-		List<String> names = new Vector<String>();
+		List<String> names = new Vector<>();
 
 		if (interpreter instanceof ClassInterpreter)
 		{
@@ -166,7 +166,7 @@ public class RemoteInterpreter
 
 	public List<String> getClasses() throws Exception
 	{
-		List<String> names = new Vector<String>();
+		List<String> names = new Vector<>();
 
 		if (interpreter instanceof ClassInterpreter)
 		{
@@ -191,8 +191,8 @@ public class RemoteInterpreter
 		}
 	}
 
-	ArrayBlockingQueue<Call> executionQueueRequest = new ArrayBlockingQueue<Call>(1);
-	ArrayBlockingQueue<Object> executionQueueResult = new ArrayBlockingQueue<Object>(1);
+	ArrayBlockingQueue<Call> executionQueueRequest = new ArrayBlockingQueue<>(1);
+	ArrayBlockingQueue<Object> executionQueueResult = new ArrayBlockingQueue<>(1);
 	private boolean isFinished;
 
 	public static class Call

--- a/core/interpreter/src/main/java/org/overture/interpreter/eval/ExpressionEvaluator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/eval/ExpressionEvaluator.java
@@ -1894,7 +1894,7 @@ public class ExpressionEvaluator extends BinaryExpressionEvaluator
 
 		if (polyfuncs == null)
 		{
-			polyfuncs = new HashMap<List<PType>, FunctionValue>();
+			polyfuncs = new HashMap<>();
 		} else
 		{
 			// We always return the same function value for a polymorph

--- a/core/interpreter/src/main/java/org/overture/interpreter/eval/StatementEvaluator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/eval/StatementEvaluator.java
@@ -231,7 +231,7 @@ public class StatementEvaluator extends DelegateExpressionEvaluator
 		try
 		{
 			ctxt.threadState.setAtomic(true);
-			List<ValueListenerList> listenerLists = new Vector<ValueListenerList>(size);
+			List<ValueListenerList> listenerLists = new Vector<>(size);
 
 			for (int i = 0; i < size; i++)
 			{

--- a/core/interpreter/src/main/java/org/overture/interpreter/messages/VDMMessage.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/messages/VDMMessage.java
@@ -38,7 +38,7 @@ public class VDMMessage
 	public final String message;
 	public final ILexLocation location;
 
-	protected List<String> details = new Vector<String>();
+	protected List<String> details = new Vector<>();
 
 	public VDMMessage(int number)
 	{

--- a/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/RTLogger.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/RTLogger.java
@@ -41,7 +41,7 @@ public class RTLogger
 	static int eventCount = 0;
 	static boolean enabled = false;
 
-	private static List<IRTLogger> loggers = new Vector<IRTLogger>();
+	private static List<IRTLogger> loggers = new Vector<>();
 
 	static
 	{

--- a/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/RTMessage.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/RTMessage.java
@@ -15,8 +15,8 @@ public abstract class RTMessage
 		Request, Activate, Completed
 	}
 
-	static Map<String, Long> staticIds = new Hashtable<String, Long>();
-	public final static List<RTDeployStaticMessage> cachedStaticDeploys = new Vector<RTDeployStaticMessage>();
+	static Map<String, Long> staticIds = new Hashtable<>();
+	public final static List<RTDeployStaticMessage> cachedStaticDeploys = new Vector<>();
 
 	protected Long time = SystemClock.getWallTime();// Timestamp the message
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/RTTextLogger.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/RTTextLogger.java
@@ -14,7 +14,7 @@ import org.overture.interpreter.messages.rtlog.RTThreadSwapMessage.SwapType;
 
 public class RTTextLogger implements IRTLogger
 {
-	private List<RTMessage> events = new LinkedList<RTMessage>();
+	private List<RTMessage> events = new LinkedList<>();
 	private File logfile = null;
 	private RTMessage cached = null;
 	private boolean enabled = false;

--- a/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/nextgen/NextGenRTLogger.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/messages/rtlog/nextgen/NextGenRTLogger.java
@@ -57,15 +57,15 @@ public class NextGenRTLogger implements IRTLogger
 		return logger;
 	}
 
-	private Map<Integer, NextGenCpu> cpuMap = new HashMap<Integer, NextGenCpu>();
-	private Map<Integer, NextGenBus> busMap = new HashMap<Integer, NextGenBus>();
-	private Map<Integer, NextGenObject> objectMap = new HashMap<Integer, NextGenObject>();
-	private Map<Integer, NextGenClassDefinition> classDefMap = new HashMap<Integer, NextGenClassDefinition>();
-	private Map<String, NextGenOperation> operationMap = new HashMap<String, NextGenOperation>();
-	private Map<Long, NextGenBusMessage> busMessage = new HashMap<Long, NextGenBusMessage>();
-	private Map<Long, NextGenThread> threadMap = new HashMap<Long, NextGenThread>();
+	private Map<Integer, NextGenCpu> cpuMap = new HashMap<>();
+	private Map<Integer, NextGenBus> busMap = new HashMap<>();
+	private Map<Integer, NextGenObject> objectMap = new HashMap<>();
+	private Map<Integer, NextGenClassDefinition> classDefMap = new HashMap<>();
+	private Map<String, NextGenOperation> operationMap = new HashMap<>();
+	private Map<Long, NextGenBusMessage> busMessage = new HashMap<>();
+	private Map<Long, NextGenThread> threadMap = new HashMap<>();
 	// private ArrayList<INextGenEvent> events = new ArrayList<INextGenEvent>();
-	private Map<Long, ArrayList<INextGenEvent>> events = new TreeMap<Long, ArrayList<INextGenEvent>>();
+	private Map<Long, ArrayList<INextGenEvent>> events = new TreeMap<>();
 	private NextGenBus vBus;
 	private File logFile = null;
 	private long currentAbsoluteTime = -1L;
@@ -73,7 +73,7 @@ public class NextGenRTLogger implements IRTLogger
 
 	public NextGenRTLogger()
 	{
-		this.addBus(0, new ArrayList<Integer>(), "vBus");
+		this.addBus(0, new ArrayList<>(), "vBus");
 		vBus = this.busMap.get(0);
 		this.addCpu(0, false, "vCpu", "system"); // Add the implicit virtual CPU - assuming expl means explicit
 	}
@@ -538,7 +538,7 @@ public class NextGenRTLogger implements IRTLogger
 
 	private void addBus(int busNumber, List<Integer> cpus, String name)
 	{
-		ArrayList<NextGenCpu> newCpus = new ArrayList<NextGenCpu>();
+		ArrayList<NextGenCpu> newCpus = new ArrayList<>();
 
 		for (Integer cpuId : cpus)
 		{
@@ -619,7 +619,7 @@ public class NextGenRTLogger implements IRTLogger
 
 	private List<Integer> parseCpuIds(String cpus)
 	{
-		List<Integer> res = new ArrayList<Integer>();
+		List<Integer> res = new ArrayList<>();
 
 		cpus = cpus.replace("{", "");
 		cpus = cpus.replace("}", "");
@@ -711,7 +711,7 @@ public class NextGenRTLogger implements IRTLogger
 
 		if (!events.containsKey(eventTime.getAbsoluteTime()))
 		{
-			events.put(eventTime.getAbsoluteTime(), new ArrayList<INextGenEvent>());
+			events.put(eventTime.getAbsoluteTime(), new ArrayList<>());
 		}
 
 		ArrayList<INextGenEvent> eventList = events.get(eventTime.getAbsoluteTime());

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/ClassInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/ClassInterpreter.java
@@ -448,7 +448,7 @@ public class ClassInterpreter extends Interpreter
 	public List<Object> runOneTrace(ANamedTraceDefinition tracedef,
 			CallSequence test, boolean debug) throws AnalysisException
 	{
-		List<Object> list = new Vector<Object>();
+		List<Object> list = new Vector<>();
 		Context ctxt = null;
 
 		try

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/CloneTrancientMemoryCache.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/CloneTrancientMemoryCache.java
@@ -46,7 +46,7 @@ class CloneTrancientMemoryCache<T>
 		}
 	}
 
-	Map<Integer, EntryPair<Integer, T>> map = new HashMap<Integer, EntryPair<Integer, T>>();
+	Map<Integer, EntryPair<Integer, T>> map = new HashMap<>();
 
 	public synchronized int store(T o)
 	{
@@ -54,7 +54,7 @@ class CloneTrancientMemoryCache<T>
 		EntryPair<Integer, T> val = map.get(key);
 		if (val == null)
 		{
-			val = new EntryPair<Integer, T>(1, o);
+			val = new EntryPair<>(1, o);
 			map.put(key, val);
 		} else
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/CollectedContextException.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/CollectedContextException.java
@@ -21,7 +21,7 @@ public class CollectedContextException extends ContextException implements
 	public CollectedContextException(ContextException toThrow,
 			Set<ContextException> problems)
 	{
-		this(toThrow, new Vector<Exception>(problems));
+		this(toThrow, new Vector<>(problems));
 	}
 
 	/**

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/CollectedExceptions.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/CollectedExceptions.java
@@ -16,7 +16,7 @@ public class CollectedExceptions extends RuntimeException implements
 
 	public CollectedExceptions(Set<ContextException> problems)
 	{
-		this(new Vector<Exception>(problems));
+		this(new Vector<>(problems));
 	}
 
 	/**

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/Context.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/Context.java
@@ -51,7 +51,7 @@ public class Context extends LexNameTokenMap<Value>
 	/** The running debug id of contexts */
 	private static int nextid = 0;
 	/** cache for transient serialization */
-	private static final CloneTrancientMemoryCache<ThreadState> serilizationCache = new CloneTrancientMemoryCache<ThreadState>();
+	private static final CloneTrancientMemoryCache<ThreadState> serilizationCache = new CloneTrancientMemoryCache<>();
 	/** The debug if of this context */
 	protected final int id;
 	/** The Assistant factory used by this context */

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/Interpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/Interpreter.java
@@ -107,8 +107,8 @@ abstract public class Interpreter
 	public Interpreter(IInterpreterAssistantFactory assistantFactory)
 	{
 		scheduler = new ResourceScheduler();
-		breakpoints = new TreeMap<Integer, Breakpoint>();
-		sourceFiles = new HashMap<File, SourceFile>();
+		breakpoints = new TreeMap<>();
+		sourceFiles = new HashMap<>();
 		this.assistantFactory = assistantFactory;
 		instance = this;
 	}

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/LatexSourceFile.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/LatexSourceFile.java
@@ -26,7 +26,7 @@ public class LatexSourceFile extends SourceFile
 	private static final String BREAKLINES_OPTION = "[breaklines=true]";
 	private static final String BEGIN = "\\begin";
 	private static final String END = "\\end";
-	public List<String> rawLines = new Vector<String>();
+	public List<String> rawLines = new Vector<>();
 	public final boolean hasVdm_al;
 	// The argument to lstset is: escapeinside={(*@}{@*)}
 	public final String LST_ESCAPE_BEGIN = "(*@";

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/ModuleInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/ModuleInterpreter.java
@@ -361,7 +361,7 @@ public class ModuleInterpreter extends Interpreter
 	public List<Object> runOneTrace(ANamedTraceDefinition tracedef,
 			CallSequence test, boolean debug)
 	{
-		List<Object> list = new Vector<Object>();
+		List<Object> list = new Vector<>();
 		Context ctxt = null;
 
 		try

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/SourceFile.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/SourceFile.java
@@ -47,7 +47,7 @@ public class SourceFile
 {
 	public final File filename;
 	public final String charset;
-	public List<String> lines = new Vector<String>();
+	public List<String> lines = new Vector<>();
 
 	private final static String HTMLSTART = "<p class=MsoNormal style='text-autospace:none'><span style='font-size:10.0pt; font-family:\"Courier New\"; color:black'>";
 	private final static String HTMLEND = "</span></p>";

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/BasicRuntimeValidator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/BasicRuntimeValidator.java
@@ -48,8 +48,8 @@ import org.overture.interpreter.values.Value;
 public class BasicRuntimeValidator implements IRuntimeValidatior
 {
 
-	final List<ConjectureDefinition> conjectures = new ArrayList<ConjectureDefinition>();
-	final List<String[]> variables = new ArrayList<String[]>();
+	final List<ConjectureDefinition> conjectures = new ArrayList<>();
+	final List<String[]> variables = new ArrayList<>();
 
 	public void init(ClassInterpreter classInterpreter)
 	{
@@ -115,7 +115,7 @@ public class BasicRuntimeValidator implements IRuntimeValidatior
 	private Value digInCtxt(String[] strings, Context ctxt)
 	{
 
-		List<String> rest = new ArrayList<String>();
+		List<String> rest = new ArrayList<>();
 		for (int i = 1; i < strings.length; i++)
 		{
 			rest.add(strings[i]);

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/ConjectureDefinition.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/ConjectureDefinition.java
@@ -38,7 +38,7 @@ public abstract class ConjectureDefinition
 	public ValueValidationExpression valueExpr;
 	public IValidationExpression endingExpr;
 	public int interval;
-	private List<ConjectureValue> conjectureValues = new ArrayList<ConjectureValue>();
+	private List<ConjectureValue> conjectureValues = new ArrayList<>();
 	public boolean startupValue;
 
 	public ConjectureDefinition(String name,
@@ -95,7 +95,7 @@ public abstract class ConjectureDefinition
 
 	public List<String[]> getMonitoredValues()
 	{
-		List<String[]> res = new ArrayList<String[]>();
+		List<String[]> res = new ArrayList<>();
 
 		if (this.valueExpr != null)
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/TimingInvariantsParser.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/TimingInvariantsParser.java
@@ -89,7 +89,7 @@ public class TimingInvariantsParser
 
 	private List<ConjectureDefinition> parse(String contents)
 	{
-		List<ConjectureDefinition> defs = new Vector<ConjectureDefinition>();
+		List<ConjectureDefinition> defs = new Vector<>();
 
 		try
 		{
@@ -108,7 +108,7 @@ public class TimingInvariantsParser
 				List<String> elems = null;
 				if (elemsFirst.size() > 3)
 				{
-					elems = new ArrayList<String>();
+					elems = new ArrayList<>();
 					elems.add(elemsFirst.get(0) + "," + elemsFirst.get(1));
 					elems.add(elemsFirst.get(2));
 					elems.add(elemsFirst.get(3));
@@ -158,7 +158,7 @@ public class TimingInvariantsParser
 
 	private List<IValidationExpression> decodeArg(String string)
 	{
-		List<IValidationExpression> res = new ArrayList<IValidationExpression>();
+		List<IValidationExpression> res = new ArrayList<>();
 		string = string.trim();
 		if (string.startsWith("("))
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/ValueValidationExpression.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/runtime/validation/ValueValidationExpression.java
@@ -94,7 +94,7 @@ public class ValueValidationExpression implements IValidationExpression
 
 	public List<String[]> getMonitoredValues()
 	{
-		ArrayList<String[]> res = new ArrayList<String[]>();
+		ArrayList<String[]> res = new ArrayList<>();
 		res.add(leftName);
 		res.add(rightName);
 		return res;

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/BUSResource.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/BUSResource.java
@@ -57,7 +57,7 @@ public class BUSResource extends Resource
 		this.cq = new ControlQueue();
 		this.speed = speed;
 		this.cpus = cpus;
-		this.messages = new LinkedList<MessagePacket>();
+		this.messages = new LinkedList<>();
 
 		busThread = null;
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/BasicSchedulableThread.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/BasicSchedulableThread.java
@@ -38,7 +38,7 @@ public class BasicSchedulableThread implements Serializable
 {
 	private static final long serialVersionUID = 1L;
 
-	private static List<ISchedulableThread> allThreads = new LinkedList<ISchedulableThread>();
+	private static List<ISchedulableThread> allThreads = new LinkedList<>();
 
 	private static InitThread initialThread = null;
 
@@ -198,7 +198,7 @@ public class BasicSchedulableThread implements Serializable
 	{
 		synchronized (allThreads)
 		{
-			List<ISchedulableThread> list = new Vector<ISchedulableThread>();
+			List<ISchedulableThread> list = new Vector<>();
 
 			for (ISchedulableThread th : allThreads)
 			{

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/CTMainThread.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/CTMainThread.java
@@ -47,7 +47,7 @@ public class CTMainThread extends MainThread
 	private final CallSequence test;
 	private final boolean debug;
 
-	private List<Object> result = new Vector<Object>();
+	private List<Object> result = new Vector<>();
 
 	public CTMainThread(CallSequence test, Context ctxt, boolean debug)
 	{

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/ControlQueue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/ControlQueue.java
@@ -35,7 +35,7 @@ public class ControlQueue implements Serializable
 	private static final long serialVersionUID = 1L;
 	private ISchedulableThread joined = null;
 	private boolean stimmed = false;
-	private List<ISchedulableThread> waiters = new LinkedList<ISchedulableThread>();
+	private List<ISchedulableThread> waiters = new LinkedList<>();
 
 	public void reset()
 	{

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/FCFSPolicy.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/FCFSPolicy.java
@@ -41,7 +41,7 @@ public class FCFSPolicy extends SchedulingPolicy
 
 	public FCFSPolicy()
 	{
-		threads = new LinkedList<ISchedulableThread>();
+		threads = new LinkedList<>();
 		PRNG = new Random(); // NB deliberately non-deterministic!
 	}
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/FPPolicy.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/FPPolicy.java
@@ -35,7 +35,7 @@ public class FPPolicy extends FCFSPolicy
 
 	public FPPolicy()
 	{
-		this.priorities = new HashMap<ISchedulableThread, Long>();
+		this.priorities = new HashMap<>();
 	}
 
 	@Override

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/Lock.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/Lock.java
@@ -35,7 +35,7 @@ public class Lock implements Serializable
 {
 	private static final long serialVersionUID = 1L;
 	private ISchedulableThread lockedBy = null;
-	private Set<ISchedulableThread> waiters = new HashSet<ISchedulableThread>();
+	private Set<ISchedulableThread> waiters = new HashSet<>();
 
 	public void reset()
 	{

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/MainThread.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/MainThread.java
@@ -51,7 +51,7 @@ public class MainThread extends SchedulablePoolThread
 	public final PExp expression;
 
 	private Value result = new UndefinedValue();
-	protected Vector<Exception> exception = new Vector<Exception>();
+	protected Vector<Exception> exception = new Vector<>();
 
 	public MainThread(PExp expr, Context ctxt)
 	{
@@ -59,7 +59,7 @@ public class MainThread extends SchedulablePoolThread
 
 		this.expression = expr;
 		this.ctxt = ctxt;
-		this.exception = new Vector<Exception>();
+		this.exception = new Vector<>();
 
 		setName("MainThread-" + getId());
 	}

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/ResourceScheduler.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/ResourceScheduler.java
@@ -36,7 +36,7 @@ public class ResourceScheduler implements Serializable
 	private static final long serialVersionUID = 1L;
 
 	public String name = "scheduler";
-	protected List<Resource> resources = new LinkedList<Resource>();
+	protected List<Resource> resources = new LinkedList<>();
 	protected static boolean stopping = false;
 	protected static MainThread mainThread = null;
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/SchedulablePoolThread.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/SchedulablePoolThread.java
@@ -129,7 +129,7 @@ public abstract class SchedulablePoolThread implements Serializable, Runnable,
 	 * OutOfMemoryError before Integer.MAX_VALUE is reached do the the native thread creation requiring 2 MB for each
 	 * thread. <a href="http://java.sun.com/j2se/1.5.0/docs/api/java/util/concurrent/ThreadPoolExecutor.html">link</a>
 	 */
-	public final static VdmThreadPoolExecutor pool = new VdmThreadPoolExecutor(200, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<Runnable>());// LinkedBlockingQueue
+	public final static VdmThreadPoolExecutor pool = new VdmThreadPoolExecutor(200, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue<>());// LinkedBlockingQueue
 
 	public SchedulablePoolThread(Resource resource, ObjectValue object,
 			long priority, boolean periodic, long swapInBy)

--- a/core/interpreter/src/main/java/org/overture/interpreter/scheduler/SharedStateListner.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/scheduler/SharedStateListner.java
@@ -58,7 +58,7 @@ public class SharedStateListner
 		boolean reuiresCheck(PStateDesignator target);
 	}
 
-	private static final Set<ILexLocation> values = new HashSet<ILexLocation>();
+	private static final Set<ILexLocation> values = new HashSet<>();
 	private static Boolean autoIncrementTime = true;
 	private static IdentityChecker checker = null;
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/AlternativeTraceNode.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/AlternativeTraceNode.java
@@ -40,7 +40,7 @@ public class AlternativeTraceNode extends TraceNode implements
 
 	public AlternativeTraceNode()
 	{
-		this.alternatives = new Vector<TraceNode>();
+		this.alternatives = new Vector<>();
 	}
 
 	@Override
@@ -88,7 +88,7 @@ public class AlternativeTraceNode extends TraceNode implements
 			return indics.size();
 		}
 		
-		indics = new HashMap<Integer, Pair<Integer, Integer>>();
+		indics = new HashMap<>();
 		int k=0;
 		
 		for (TraceNode node : alternatives)
@@ -107,7 +107,7 @@ public class AlternativeTraceNode extends TraceNode implements
 			
 			for (int i = 0; i < s; i++)
 			{
-				indics.put(size+i, new Pair<Integer,Integer>(k,i));
+				indics.put(size+i, new Pair<>(k, i));
 			}
 			
 			size+=s;

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/ConcurrentTraceNode.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/ConcurrentTraceNode.java
@@ -39,7 +39,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 
 	public ConcurrentTraceNode()
 	{
-		nodes = new Vector<TraceNode>();
+		nodes = new Vector<>();
 	}
 
 	@Override
@@ -51,7 +51,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 		}
 		Pair<Integer, Integer> v = indics.get(index);
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new Vector<>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)
@@ -124,11 +124,11 @@ public class ConcurrentTraceNode extends TraceNode implements
 			return indics.size();
 		}
 
-		indics = new HashMap<Integer, Pair<Integer, Integer>>();
+		indics = new HashMap<>();
 
 		int size = 0;
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new Vector<>();
 		int count = nodes.size();
 
 		for (TraceNode node : nodes)
@@ -157,7 +157,7 @@ public class ConcurrentTraceNode extends TraceNode implements
 			{
 				j++;
 				p.next();
-				indics.put(size, new Pair<Integer, Integer>(r, j));
+				indics.put(size, new Pair<>(r, j));
 				size++;
 			}
 		}

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/ReducedTestSequence.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/ReducedTestSequence.java
@@ -96,7 +96,7 @@ public class ReducedTestSequence extends TestSequence
 		private int size;
 		private TraceReductionType type;
 
-		private List<Integer> chosenTestIndices = new Vector<Integer>();
+		private List<Integer> chosenTestIndices = new Vector<>();
 		private int choosenIndexPtr = 0;
 		private Iterator<CallSequence> choosenTestItr;
 		private int choosenTestIndexPtr = 0;
@@ -115,7 +115,7 @@ public class ReducedTestSequence extends TestSequence
 
 		private void initialize()
 		{
-			Map<String, List<Integer>> map = new HashMap<String, List<Integer>>();
+			Map<String, List<Integer>> map = new HashMap<>();
 
 			int index = 0;
 			for (Iterator<CallSequence> itr = data.iterator(); itr.hasNext();)
@@ -125,7 +125,7 @@ public class ReducedTestSequence extends TestSequence
 
 				if (subset == null)
 				{
-					subset = new Vector<Integer>();
+					subset = new Vector<>();
 					map.put(shape, subset);
 				}
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/RepeatTraceNode.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/RepeatTraceNode.java
@@ -115,7 +115,7 @@ public class RepeatTraceNode extends TraceNode implements IIterableTraceNode
 			return indics.size();
 		}
 
-		indics = new HashMap<Integer, Pair<Integer, Integer>>();
+		indics = new HashMap<>();
 
 		int size = 0;
 		TestSequence rtests = repeat.getTests();
@@ -125,7 +125,7 @@ public class RepeatTraceNode extends TraceNode implements IIterableTraceNode
 			if (r == 0)
 			{
 
-				indics.put(size, new Pair<Integer, Integer>(r, 0));
+				indics.put(size, new Pair<>(r, 0));
 				size++;
 				continue;
 			}
@@ -144,7 +144,7 @@ public class RepeatTraceNode extends TraceNode implements IIterableTraceNode
 			{
 				j++;
 				p.next();
-				indics.put(size, new Pair<Integer, Integer>(r, j));
+				indics.put(size, new Pair<>(r, j));
 				size++;
 			}
 		}

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/SequenceTraceNode.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/SequenceTraceNode.java
@@ -38,7 +38,7 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 
 	public SequenceTraceNode()
 	{
-		this.nodes = new Vector<TraceNode>();
+		this.nodes = new Vector<>();
 	}
 
 	@Override
@@ -52,7 +52,7 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 
 		CallSequence seq = getVariables();
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new Vector<>();
 		int count = nodes.size();
 
 		// TODO not good, poor performance
@@ -89,9 +89,9 @@ public class SequenceTraceNode extends TraceNode implements IIterableTraceNode
 			return indics.size();
 		}
 
-		indics = new HashMap<Integer, Integer[]>();
+		indics = new HashMap<>();
 
-		List<TestSequence> nodetests = new Vector<TestSequence>();
+		List<TestSequence> nodetests = new Vector<>();
 		int count = nodes.size();
 		int[] sizes = new int[count];
 		int n = 0;

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/TestSequence.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/TestSequence.java
@@ -46,7 +46,7 @@ public class TestSequence extends Vector<CallSequence>
 		}
 	}
 
-	final List<TestData> failedCallSeqs = new Vector<TestData>();
+	final List<TestData> failedCallSeqs = new Vector<>();
 
 	/**
 	 * Filter remaining tests based on one set of results. The result list passed in is the result of running the test,

--- a/core/interpreter/src/main/java/org/overture/interpreter/traces/TypeCheckedTestSequence.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/traces/TypeCheckedTestSequence.java
@@ -7,7 +7,7 @@ import org.overture.parser.messages.VDMErrorsException;
 
 public class TypeCheckedTestSequence extends TestSequence
 {
-	Map<CallSequence, VDMErrorsException> tcFailedTests = new HashMap<CallSequence, VDMErrorsException>();
+	Map<CallSequence, VDMErrorsException> tcFailedTests = new HashMap<>();
 	/**
 	 * 
 	 */

--- a/core/interpreter/src/main/java/org/overture/interpreter/util/ClassListInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/util/ClassListInterpreter.java
@@ -109,7 +109,7 @@ public class ClassListInterpreter extends ClassList
 
 		ContextException failed = null;
 		int retries = 3; // Potentially not enough.
-		Set<ContextException> trouble = new HashSet<ContextException>();
+		Set<ContextException> trouble = new HashSet<>();
 
 		do
 		{
@@ -247,7 +247,7 @@ public class ClassListInterpreter extends ClassList
 			}
 
 			// Run the constructor to do any deploys etc.
-			ASystemClassDefinitionRuntime.system = initialContext.assistantFactory.createSClassDefinitionAssistant().makeNewInstance(systemClass, null, new ValueList(), initialContext, new HashMap<ILexNameToken, ObjectValue>(), false);
+			ASystemClassDefinitionRuntime.system = initialContext.assistantFactory.createSClassDefinitionAssistant().makeNewInstance(systemClass, null, new ValueList(), initialContext, new HashMap<>(), false);
 
 			// Bind system instances to runtime validator
 			RuntimeValidator.bindSystemVariables(systemClass, initialContext.assistantFactory);

--- a/core/interpreter/src/main/java/org/overture/interpreter/util/Delegate.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/util/Delegate.java
@@ -77,8 +77,8 @@ public class Delegate implements Serializable
 			{
 				String classname = name.replace('_', '.');
 				delegateClass = this.getClass().getClassLoader().loadClass(classname);
-				delegateMethods = new HashMap<String, Method>();
-				delegateArgs = new HashMap<String, LexNameList>();
+				delegateMethods = new HashMap<>();
+				delegateArgs = new HashMap<>();
 				definitions = assistantFactory.createPDefinitionListAssistant().singleDefinitions(definitions);
 			} catch (ClassNotFoundException e)
 			{
@@ -158,7 +158,7 @@ public class Delegate implements Serializable
 			}
 
 			LexNameList anames = new LexNameList();
-			List<Class<?>> ptypes = new Vector<Class<?>>();
+			List<Class<?>> ptypes = new Vector<>();
 
 			if (plist != null)
 			{

--- a/core/interpreter/src/main/java/org/overture/interpreter/utilities/pattern/AllNamedValuesLocator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/utilities/pattern/AllNamedValuesLocator.java
@@ -82,7 +82,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseABooleanPattern(ABooleanPattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 
 		try
 		{
@@ -104,7 +104,7 @@ public class AllNamedValuesLocator
 			ACharacterPattern pattern, Newquestion question)
 			throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 
 		try
 		{
@@ -153,7 +153,7 @@ public class AllNamedValuesLocator
 		// generate a set of splits of the values, and offer these to sub-matches
 		// to see whether they fit. Otherwise, there is just one split at this level.
 
-		List<Integer> leftSizes = new Vector<Integer>();
+		List<Integer> leftSizes = new Vector<>();
 
 		if (llen == PPatternAssistantInterpreter.ANY)
 		{
@@ -208,7 +208,7 @@ public class AllNamedValuesLocator
 		// Now loop through the various splits and attempt to match the l/r
 		// sub-patterns to the split sequence value.
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new Vector<>();
 
 		for (Integer lsize : leftSizes)
 		{
@@ -227,7 +227,7 @@ public class AllNamedValuesLocator
 				tail.add(iter.next());
 			}
 
-			List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+			List<List<NameValuePairList>> nvplists = new Vector<>();
 			int psize = 2;
 			int[] counts = new int[psize];
 
@@ -295,7 +295,7 @@ public class AllNamedValuesLocator
 			AExpressionPattern pattern, Newquestion question)
 			throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 
 		try
 		{
@@ -321,7 +321,7 @@ public class AllNamedValuesLocator
 			AIdentifierPattern pattern, Newquestion question)
 			throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 		NameValuePairList list = new NameValuePairList();
 		list.add(new NameValuePair(pattern.getName(), question.expval));
 		result.add(list);
@@ -332,7 +332,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseAIgnorePattern(AIgnorePattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 		result.add(new NameValuePairList());
 		return result;
 	}
@@ -341,7 +341,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseAIntegerPattern(AIntegerPattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 
 		try
 		{
@@ -390,11 +390,11 @@ public class AllNamedValuesLocator
 			allMaps = values.permutedMaps();
 		} else
 		{
-			allMaps = new Vector<ValueMap>();
+			allMaps = new Vector<>();
 			allMaps.add(values);
 		}
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new Vector<>();
 		int psize = pattern.getMaplets().size();
 
 		if (pattern.getMaplets().isEmpty())
@@ -407,7 +407,7 @@ public class AllNamedValuesLocator
 		{
 			Iterator<Entry<Value, Value>> iter = mapPerm.entrySet().iterator();
 
-			List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+			List<List<NameValuePairList>> nvplists = new Vector<>();
 			int[] counts = new int[psize];
 			int i = 0;
 
@@ -501,7 +501,7 @@ public class AllNamedValuesLocator
 		// generate a set of splits of the values, and offer these to sub-matches
 		// to see whether they fit. Otherwise, there is just one split at this level.
 
-		List<Integer> leftSizes = new Vector<Integer>();
+		List<Integer> leftSizes = new Vector<>();
 
 		if (llen == PPatternAssistantInterpreter.ANY)
 		{
@@ -566,14 +566,14 @@ public class AllNamedValuesLocator
 			allMaps = values.permutedMaps();
 		} else
 		{
-			allMaps = new Vector<ValueMap>();
+			allMaps = new Vector<>();
 			allMaps.add(values);
 		}
 
 		// Now loop through the various splits and attempt to match the l/r
 		// sub-patterns to the split map value.
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new Vector<>();
 
 		for (Integer lsize : leftSizes)
 		{
@@ -596,7 +596,7 @@ public class AllNamedValuesLocator
 					second.put(e.getKey(), e.getValue());
 				}
 
-				List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+				List<List<NameValuePairList>> nvplists = new Vector<>();
 				int psize = 2;
 				int[] counts = new int[psize];
 
@@ -665,7 +665,7 @@ public class AllNamedValuesLocator
 			Newquestion question) throws AnalysisException
 	{
 		// return ANilPatternAssistantInterpreter.getAllNamedValues(pattern, question.expval, question.ctxt);
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 
 		if (!(question.expval.deref() instanceof NilValue))
 		{
@@ -680,7 +680,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseAQuotePattern(AQuotePattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 
 		try
 		{
@@ -701,7 +701,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseARealPattern(ARealPattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 
 		try
 		{
@@ -746,7 +746,7 @@ public class AllNamedValuesLocator
 		}
 
 		Iterator<FieldValue> iter = fields.iterator();
-		List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+		List<List<NameValuePairList>> nvplists = new Vector<>();
 		int psize = pattern.getPlist().size();
 		int[] counts = new int[psize];
 		int i = 0;
@@ -759,7 +759,7 @@ public class AllNamedValuesLocator
 		}
 
 		Permutor permutor = new Permutor(counts);
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new Vector<>();
 
 		if (pattern.getPlist().isEmpty())
 		{
@@ -829,7 +829,7 @@ public class AllNamedValuesLocator
 		}
 
 		ListIterator<Value> iter = values.listIterator();
-		List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+		List<List<NameValuePairList>> nvplists = new Vector<>();
 		int psize = pattern.getPlist().size();
 		int[] counts = new int[psize];
 		int i = 0;
@@ -842,7 +842,7 @@ public class AllNamedValuesLocator
 		}
 
 		Permutor permutor = new Permutor(counts);
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new Vector<>();
 
 		if (pattern.getPlist().isEmpty())
 		{
@@ -925,11 +925,11 @@ public class AllNamedValuesLocator
 			allSets = values.permutedSets();
 		} else
 		{
-			allSets = new Vector<ValueSet>();
+			allSets = new Vector<>();
 			allSets.add(values);
 		}
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new Vector<>();
 		int psize = pattern.getPlist().size();
 
 		if (pattern.getPlist().isEmpty())
@@ -942,7 +942,7 @@ public class AllNamedValuesLocator
 		{
 			Iterator<Value> iter = setPerm.iterator();
 
-			List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+			List<List<NameValuePairList>> nvplists = new Vector<>();
 			int[] counts = new int[psize];
 			int i = 0;
 
@@ -1008,7 +1008,7 @@ public class AllNamedValuesLocator
 	public List<NameValuePairList> caseAStringPattern(AStringPattern pattern,
 			Newquestion question) throws AnalysisException
 	{
-		List<NameValuePairList> result = new Vector<NameValuePairList>();
+		List<NameValuePairList> result = new Vector<>();
 
 		try
 		{
@@ -1045,7 +1045,7 @@ public class AllNamedValuesLocator
 		}
 
 		ListIterator<Value> iter = values.listIterator();
-		List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+		List<List<NameValuePairList>> nvplists = new Vector<>();
 		int psize = pattern.getPlist().size();
 		int[] counts = new int[psize];
 		int i = 0;
@@ -1059,7 +1059,7 @@ public class AllNamedValuesLocator
 		}
 
 		Permutor permutor = new Permutor(counts);
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new Vector<>();
 
 		while (permutor.hasNext())
 		{
@@ -1134,7 +1134,7 @@ public class AllNamedValuesLocator
 		// generate a set of splits of the values, and offer these to sub-matches
 		// to see whether they fit. Otherwise, there is just one split at this level.
 
-		List<Integer> leftSizes = new Vector<Integer>();
+		List<Integer> leftSizes = new Vector<>();
 
 		if (llen == PPatternAssistantInterpreter.ANY)
 		{
@@ -1199,14 +1199,14 @@ public class AllNamedValuesLocator
 			allSets = values.permutedSets();
 		} else
 		{
-			allSets = new Vector<ValueSet>();
+			allSets = new Vector<>();
 			allSets.add(values);
 		}
 
 		// Now loop through the various splits and attempt to match the l/r
 		// sub-patterns to the split set value.
 
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new Vector<>();
 
 		for (Integer lsize : leftSizes)
 		{
@@ -1227,7 +1227,7 @@ public class AllNamedValuesLocator
 					second.add(iter.next());
 				}
 
-				List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+				List<List<NameValuePairList>> nvplists = new Vector<>();
 				int psize = 2;
 				int[] counts = new int[psize];
 
@@ -1311,7 +1311,7 @@ public class AllNamedValuesLocator
 			VdmRuntimeError.patternFail(4114, "Object type does not match pattern", pattern.getLocation());
 		}
 
-		List<List<NameValuePairList>> nvplists = new Vector<List<NameValuePairList>>();
+		List<List<NameValuePairList>> nvplists = new Vector<>();
 		int psize = pattern.getFields().size();
 		int[] counts = new int[psize];
 		int i = 0;
@@ -1331,7 +1331,7 @@ public class AllNamedValuesLocator
 		}
 
 		Permutor permutor = new Permutor(counts);
-		List<NameValuePairList> finalResults = new Vector<NameValuePairList>();
+		List<NameValuePairList> finalResults = new Vector<>();
 
 		if (pattern.getFields().isEmpty())
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/BUSValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/BUSValue.java
@@ -42,7 +42,7 @@ import org.overture.interpreter.scheduler.SchedulingPolicy;
 public class BUSValue extends ObjectValue
 {
 	private static final long serialVersionUID = 1L;
-	private static List<BUSValue> busses = new LinkedList<BUSValue>();
+	private static List<BUSValue> busses = new LinkedList<>();
 	private static BUSValue[][] cpumap = null;
 
 	public static BUSValue vBUS = null;
@@ -51,7 +51,7 @@ public class BUSValue extends ObjectValue
 	public BUSValue(AClassType classtype, NameValuePairMap map,
 			ValueList argvals)
 	{
-		super(classtype, map, new Vector<ObjectValue>(), null, null);
+		super(classtype, map, new Vector<>(), null, null);
 
 		QuoteValue parg = (QuoteValue) argvals.get(0);
 		SchedulingPolicy policy = SchedulingPolicy.factory(parg.value.toUpperCase());
@@ -60,7 +60,7 @@ public class BUSValue extends ObjectValue
 		double speed = sarg.value;
 
 		SetValue set = (SetValue) argvals.get(2);
-		List<CPUResource> cpulist = new Vector<CPUResource>();
+		List<CPUResource> cpulist = new Vector<>();
 
 		for (Value v : set.values)
 		{
@@ -74,8 +74,8 @@ public class BUSValue extends ObjectValue
 
 	public BUSValue(AClassType type, ValueSet cpus)
 	{
-		super(type, new NameValuePairMap(), new Vector<ObjectValue>(), null, null);
-		List<CPUResource> cpulist = new Vector<CPUResource>();
+		super(type, new NameValuePairMap(), new Vector<>(), null, null);
+		List<CPUResource> cpulist = new Vector<>();
 
 		for (Value v : cpus)
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/CPUValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/CPUValue.java
@@ -46,22 +46,22 @@ public class CPUValue extends ObjectValue
 	public CPUValue(AClassType aClassType, NameValuePairMap map,
 			ValueList argvals)
 	{
-		super(aClassType, map, new Vector<ObjectValue>(), null, null);
+		super(aClassType, map, new Vector<>(), null, null);
 
 		QuoteValue parg = (QuoteValue) argvals.get(0);
 		SchedulingPolicy cpup = SchedulingPolicy.factory(parg.value.toUpperCase());
 		RealValue sarg = (RealValue) argvals.get(1);
 
 		resource = new CPUResource(cpup, sarg.value);
-		deployed = new Vector<ObjectValue>();
+		deployed = new Vector<>();
 
 	}
 
 	public CPUValue(AClassType classtype) // for virtual CPUs
 	{
-		super(classtype, new NameValuePairMap(), new Vector<ObjectValue>(), null, null);
+		super(classtype, new NameValuePairMap(), new Vector<>(), null, null);
 		resource = new CPUResource(new FCFSPolicy(), 0);
-		deployed = new Vector<ObjectValue>();
+		deployed = new Vector<>();
 	}
 
 	public void setup(ResourceScheduler scheduler, String name)

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/FunctionValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/FunctionValue.java
@@ -139,7 +139,7 @@ public class FunctionValue extends Value
 		this.name = name;
 		this.typeValues = null;
 		this.type = type;
-		this.paramPatternList = new Vector<List<PPattern>>();
+		this.paramPatternList = new Vector<>();
 		this.body = body;
 		this.precondition = null;
 		this.postcondition = null;
@@ -170,7 +170,7 @@ public class FunctionValue extends Value
 		if (Settings.measureChecks && def.getMeasureDef() != null)
 		{
 			measureName = def.getMeasureDef().getName();
-			measureValues = Collections.synchronizedMap(new HashMap<Long, Stack<Value>>());
+			measureValues = Collections.synchronizedMap(new HashMap<>());
 		}
 	}
 
@@ -183,7 +183,7 @@ public class FunctionValue extends Value
 		this.typeValues = null;
 		this.type = (AFunctionType) def.getType();
 
-		this.paramPatternList = new Vector<List<PPattern>>();
+		this.paramPatternList = new Vector<>();
 		PatternListTC plist = Interpreter.getInstance().getAssistantFactory().createPatternList();
 
 		for (APatternListTypePair ptp : def.getParamPatterns())
@@ -204,7 +204,7 @@ public class FunctionValue extends Value
 		if (Settings.measureChecks && def.getMeasureDef() != null)
 		{
 			measureName = def.getMeasureDef().getName();
-			measureValues = Collections.synchronizedMap(new HashMap<Long, Stack<Value>>());
+			measureValues = Collections.synchronizedMap(new HashMap<>());
 		}
 	}
 
@@ -414,8 +414,8 @@ public class FunctionValue extends Value
 						measure.typeValues = typeValues;
 					}
 
-					measure.measuringThreads = Collections.synchronizedSet(new HashSet<Long>());
-					measure.callingThreads = Collections.synchronizedSet(new HashSet<Long>());
+					measure.measuringThreads = Collections.synchronizedSet(new HashSet<>());
+					measure.callingThreads = Collections.synchronizedSet(new HashSet<>());
 					measure.isMeasure = true;
 				}
 
@@ -452,7 +452,7 @@ public class FunctionValue extends Value
 
 				if (stack == null)
 				{
-					stack = new Stack<Value>();
+					stack = new Stack<>();
 					measureValues.put(tid, stack);
 				}
 
@@ -617,13 +617,13 @@ public class FunctionValue extends Value
 		Value rv = null;
 		try
 		{
-			Map<String, String> argExps = new HashMap<String, String>();
+			Map<String, String> argExps = new HashMap<>();
 			for (Entry<ILexNameToken, Value> argVal : args.entrySet())
 			{
 				argExps.put(argVal.getKey().getName(), argVal.getValue().toString());
 			}
 
-			Map<String, String> stateExps = new HashMap<String, String>();
+			Map<String, String> stateExps = new HashMap<>();
 
 			Interpreter interpreter = Interpreter.getInstance();
 			List<PDefinition> allDefs = new Vector<PDefinition>();

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ObjectValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ObjectValue.java
@@ -88,7 +88,7 @@ public class ObjectValue extends Value
 		this.superobjects = superobjects;
 		this.CPU = cpu;
 		this.guardLock = new Lock();
-		this.children = new LinkedList<ObjectValue>();
+		this.children = new LinkedList<>();
 
 		if (creator != null)
 		{
@@ -439,7 +439,7 @@ public class ObjectValue extends Value
 			return mycopy;
 		}
 
-		mycopy = new ObjectValue(type, new NameValuePairMap(), new Vector<ObjectValue>(), CPU, creator);
+		mycopy = new ObjectValue(type, new NameValuePairMap(), new Vector<>(), CPU, creator);
 
 		List<ObjectValue> supers = mycopy.superobjects;
 		NameValuePairMap memcopy = mycopy.members;
@@ -447,7 +447,7 @@ public class ObjectValue extends Value
 		for (ObjectValue sobj : superobjects)
 		{
 			supers.add( // Type skeleton only...
-			new ObjectValue(sobj.type, new NameValuePairMap(), new Vector<ObjectValue>(), sobj.CPU, creator));
+			new ObjectValue(sobj.type, new NameValuePairMap(), new Vector<>(), sobj.CPU, creator));
 		}
 
 		for (ILexNameToken name : members.keySet())

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/OperationValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/OperationValue.java
@@ -492,13 +492,13 @@ public class OperationValue extends Value
 	{
 		try
 		{
-			Map<String, String> argExps = new HashMap<String, String>();
+			Map<String, String> argExps = new HashMap<>();
 			for (Entry<ILexNameToken, Value> argVal : args.entrySet())
 			{
 				argExps.put(argVal.getKey().getName(), argVal.getValue().toString());
 			}
 
-			Map<String, String> stateExps = new HashMap<String, String>();
+			Map<String, String> stateExps = new HashMap<>();
 
 			if (stateContext != null)
 			{
@@ -708,7 +708,7 @@ public class OperationValue extends Value
 				return new VoidValue();
 			} else
 			{
-				Holder<MessageResponse> result = new Holder<MessageResponse>();
+				Holder<MessageResponse> result = new Holder<>();
 				MessageRequest request = new MessageRequest(ctxt.threadState.dbgp, bus, from, to, self, this, argValues, result, stepping);
 
 				bus.transmit(request);

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/Quantifier.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/Quantifier.java
@@ -41,7 +41,7 @@ public class Quantifier
 	{
 		this.pattern = pattern;
 		this.values = values;
-		this.nvlist = new Vector<NameValuePairList>(values.size());
+		this.nvlist = new Vector<>(values.size());
 	}
 
 	public int size(Context ctxt, boolean allPossibilities)

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/TransactionValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/TransactionValue.java
@@ -48,7 +48,7 @@ public class TransactionValue extends UpdatableValue
 {
 	private static final long serialVersionUID = 1L;
 
-	private static List<TransactionValue> commitList = new Vector<TransactionValue>();
+	private static List<TransactionValue> commitList = new Vector<>();
 
 	private Value newvalue = null; // The pending value before a commit
 	private long newthreadid = -1; // The thread that made the change

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ValueFactory.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ValueFactory.java
@@ -138,7 +138,7 @@ public class ValueFactory
 	public RecordValue createRecord(String recordName, Object... fields)
 			throws ValueFactoryException
 	{
-		List<Value> values = new Vector<Value>();
+		List<Value> values = new Vector<>();
 		for (Object object : fields)
 		{
 			if (object instanceof Boolean)

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ValueMap.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ValueMap.java
@@ -56,7 +56,7 @@ public class ValueMap extends LinkedHashMap<Value, Value>
 
 	public boolean isInjective()
 	{
-		Set<Value> rng = new HashSet<Value>(values());
+		Set<Value> rng = new HashSet<>(values());
 		return keySet().size() == rng.size();
 	}
 
@@ -100,7 +100,7 @@ public class ValueMap extends LinkedHashMap<Value, Value>
 		// This is a 1st order permutation, which does not take account of the possible
 		// nesting of maps or the presence of other permutable values with them (sets).
 
-		List<ValueMap> results = new Vector<ValueMap>();
+		List<ValueMap> results = new Vector<>();
 		Object[] entries = entrySet().toArray();
 		int size = entries.length;
 

--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ValueSet.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ValueSet.java
@@ -144,7 +144,7 @@ public class ValueSet extends Vector<Value> // NB based on Vector
 		// This is a 1st order permutation, which does not take account of the possible
 		// nesting of sets or the presence of other permutable values with them (maps).
 
-		List<ValueSet> results = new Vector<ValueSet>();
+		List<ValueSet> results = new Vector<>();
 		int size = size();
 
 		if (size == 0)
@@ -173,7 +173,7 @@ public class ValueSet extends Vector<Value> // NB based on Vector
 
 	public List<ValueSet> powerSet()
 	{
-		List<ValueSet> sets = new Vector<ValueSet>(2 ^ size());
+		List<ValueSet> sets = new Vector<>(2 ^ size());
 
 		if (isEmpty())
 		{

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/CommonInterpreterTest.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/CommonInterpreterTest.java
@@ -81,7 +81,7 @@ public abstract class CommonInterpreterTest extends StringBasedInterpreterTest
 			try
 			{
 				Value val = InterpreterUtil.interpret(Settings.dialect, entry, file);
-				result = new Result<String>(val.toString(), new Vector<IMessage>(), new Vector<IMessage>());
+				result = new Result<>(val.toString(), new Vector<>(), new Vector<>());
 				System.out.println(file.getName() + " -> " + val);
 			} catch (Exception e)
 			{
@@ -191,7 +191,7 @@ public abstract class CommonInterpreterTest extends StringBasedInterpreterTest
 	private List<String> getEntries() throws IOException
 	{
 		BufferedReader reader = new BufferedReader(new FileReader(getEntryFile()));
-		List<String> data = new Vector<String>();
+		List<String> data = new Vector<>();
 		String text = null;
 		while ((text = reader.readLine()) != null)
 		{

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/RandomListTests.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/RandomListTests.java
@@ -22,14 +22,14 @@ public class RandomListTests
 		RandomList randList = new RandomList(N, R, gen);
 		
 		
-		List<Integer> actualResults = new LinkedList<Integer>();
+		List<Integer> actualResults = new LinkedList<>();
 		
 		for(int i = 0; i < R + 1; i++)
 		{
 			actualResults.add(randList.next());
 		}
 		
-		List<Integer> expectedNumbers = new LinkedList<Integer>();
+		List<Integer> expectedNumbers = new LinkedList<>();
 		expectedNumbers.add(121);
 		expectedNumbers.add(488);
 		expectedNumbers.add(597);

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/external/AbstractExternalTest.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/external/AbstractExternalTest.java
@@ -44,10 +44,10 @@ public abstract class AbstractExternalTest extends CommonInterpreterTest
 			tests = TestSourceFinder.createTestCompleteFile(dialect, name, root.getAbsolutePath(), extension);
 		} else
 		{
-			tests = new LinkedList<Object[]>();
+			tests = new LinkedList<>();
 		}
 
-		Collection<Object[]> actualTests = new LinkedList<Object[]>();
+		Collection<Object[]> actualTests = new LinkedList<>();
 		for (Object[] objects : tests)
 		{
 			Object[] temp = objects.clone();

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/external/ExternalClassesPpTest.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/external/ExternalClassesPpTest.java
@@ -17,7 +17,7 @@ import org.overture.config.Settings;
 public class ExternalClassesPpTest extends AbstractExternalTest
 
 {
-	Set<String> classicSpecifications = new HashSet<String>(Arrays.asList(new String[] {
+	Set<String> classicSpecifications = new HashSet<>(Arrays.asList(new String[]{
 			"instvars-01.vpp", "type-02.vpp", "type-03.vpp", "type-04.vpp",
 			"depend-04.vpp", "reperr-01.vpp", "reperr-19.vpp", "reperr-21.vpp",
 			"reperr-22.vpp", "reperr-23.vpp", "reperr-24.vpp", "reperr-25.vpp",
@@ -54,7 +54,7 @@ public class ExternalClassesPpTest extends AbstractExternalTest
 			"types-40.vpp", "types-41.vpp", "types-42.vpp", "types-44.vpp",
 			"types-45.vpp", "types-46.vpp", "values-01.vpp", "values-02.vpp",
 			"values-03.vpp", "values-05.vpp", "values-06.vpp", "values-13.vpp",
-			"values-14.vpp", "invoke-15.vpp" }));
+			"values-14.vpp", "invoke-15.vpp"}));
 
 	public ExternalClassesPpTest(Dialect dialect, String suiteName,
 			File testSuiteRoot, File file, String storeLocationPart)

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/external/ExternalClassesRtTest.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/external/ExternalClassesRtTest.java
@@ -16,13 +16,13 @@ import org.overture.config.Settings;
 @RunWith(value = Parameterized.class)
 public class ExternalClassesRtTest extends AbstractExternalTest
 {
-	Set<String> classicSpecifications = new HashSet<String>(Arrays.asList(new String[] {
+	Set<String> classicSpecifications = new HashSet<>(Arrays.asList(new String[]{
 			"extension-01.vpp", "extension-07.vpp", "extension-12.vpp",
 			"extension-13.vpp", "extension-16.vpp", "fighter-01.vpp",
 			"fighter-02.vpp", "fighter-03.vpp", "fighter-04.vpp",
 			"fighter-05.vpp", "fighter-06.vpp", "fighter-07.vpp",
 			"fighter-08.vpp", "periodic-08.vpp", "periodic-09.vpp",
-			"staticext-03.vpp", "staticext-05.vpp" }));
+			"staticext-03.vpp", "staticext-05.vpp"}));
 
 	public ExternalClassesRtTest(Dialect dialect, String suiteName,
 			File testSuiteRoot, File file, String storeLocationPart)

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/external/ExternalModulesSlTest.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/external/ExternalModulesSlTest.java
@@ -17,7 +17,7 @@ import org.overture.config.Settings;
 public class ExternalModulesSlTest extends AbstractExternalTest
 {
 
-	Set<String> classicSpecifications = new HashSet<String>(Arrays.asList(new String[] {
+	Set<String> classicSpecifications = new HashSet<>(Arrays.asList(new String[]{
 			"recmodify-06.vdm", "recmodify-08.vdm", "recordexpr-05.vdm",
 			"recordexpr-06.vdm", "recordexpr-07.vdm", "recordexpr-08.vdm",
 			"tupleselect-03.vdm", "functions-12.vdm", "functions-19.vdm",
@@ -34,7 +34,7 @@ public class ExternalModulesSlTest extends AbstractExternalTest
 			"exception-09.vdm", "returnstmt-06.vdm", "assignstmt-05.vdm",
 			"types-04.vdm", "types-06.vdm", "types-10.vdm",
 			"fcttypeinst-01.vdm", "recordexpr-01.vdm", "recordexpr-02.vdm",
-			"fctcall-mods-01.vdm", "exception-01.vdm", "exception-13.vdm" }));
+			"fctcall-mods-01.vdm", "exception-01.vdm", "exception-13.vdm"}));
 
 	public ExternalModulesSlTest(Dialect dialect, String suiteName,
 			File testSuiteRoot, File file, String storeLocationPart)

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/newtests/ParamInterpreterTest.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/newtests/ParamInterpreterTest.java
@@ -61,8 +61,8 @@ public abstract class ParamInterpreterTest extends
 			Value val = InterpreterUtil.interpret(ast, entry, Settings.dialect);
 
 			StringInterpreterResult result = new StringInterpreterResult(
-					val.toString(), new Vector<Message>(),
-					new Vector<Message>());
+					val.toString(), new Vector<>(),
+					new Vector<>());
 
 			return result;
 		} catch (Exception e) {
@@ -72,11 +72,11 @@ public abstract class ParamInterpreterTest extends
 
 	private StringInterpreterResult wrap(Exception e) {
 
-		Vector<Message> errors = new Vector<Message>();
+		Vector<Message> errors = new Vector<>();
 		String message = e.getMessage();
 		if (e instanceof ICollectedRuntimeExceptions) {
-			List<String> messages = new Vector<String>();
-			List<Exception> collectedExceptions = new ArrayList<Exception>(
+			List<String> messages = new Vector<>();
+			List<Exception> collectedExceptions = new ArrayList<>(
 					((ICollectedRuntimeExceptions) e).getCollectedExceptions());
 			for (Exception err : collectedExceptions) {
 				if (err instanceof ContextException) {
@@ -101,14 +101,14 @@ public abstract class ParamInterpreterTest extends
 			Collections.sort(messages);
 			message = messages.toString();
 		}
-		return new StringInterpreterResult(message, new Vector<Message>(),
+		return new StringInterpreterResult(message, new Vector<>(),
 				errors);
 	}
 
 	private List<String> getEntries() throws IOException {
 		BufferedReader reader = new BufferedReader(new FileReader(
 				getEntryFile()));
-		List<String> data = new Vector<String>();
+		List<String> data = new Vector<>();
 		String text = null;
 		while ((text = reader.readLine()) != null) {
 			data.add(text.trim());

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/utils/ExecutionToResultTranslator.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/utils/ExecutionToResultTranslator.java
@@ -20,17 +20,17 @@ public class ExecutionToResultTranslator
 	public static Result<Value> wrapValue(Exception e)
 	{
 		Result<String> result = wrap(e);
-		return new Result<Value>(new SeqValue(result.getStringResult()), result.warnings, result.errors);
+		return new Result<>(new SeqValue(result.getStringResult()), result.warnings, result.errors);
 	}
 
 	public static Result<String> wrap(Exception e)
 	{
-		List<IMessage> errors = new Vector<IMessage>();
+		List<IMessage> errors = new Vector<>();
 		String message = e.getMessage();
 		if (e instanceof ICollectedRuntimeExceptions)
 		{
-			List<String> messages = new Vector<String>();
-			List<Exception> collectedExceptions = new ArrayList<Exception>(((ICollectedRuntimeExceptions) e).getCollectedExceptions());
+			List<String> messages = new Vector<>();
+			List<Exception> collectedExceptions = new ArrayList<>(((ICollectedRuntimeExceptions) e).getCollectedExceptions());
 			for (Exception err : collectedExceptions)
 			{
 				if (err instanceof ContextException)
@@ -54,6 +54,6 @@ public class ExecutionToResultTranslator
 			Collections.sort(messages);
 			message = messages.toString();
 		}
-		return new Result<String>(message, new Vector<IMessage>(), errors);
+		return new Result<>(message, new Vector<>(), errors);
 	}
 }

--- a/core/interpreter/src/test/java/org/overture/interpreter/tests/utils/TestSourceFinder.java
+++ b/core/interpreter/src/test/java/org/overture/interpreter/tests/utils/TestSourceFinder.java
@@ -45,7 +45,7 @@ public class TestSourceFinder
 	{
 		File testRoot = getFile(testRootPath.replace('/', File.separatorChar));
 
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -84,7 +84,7 @@ public class TestSourceFinder
 		File testRoot = getFile(testRootPath);
 
 		// TestSuite suite = new TestSourceFinder(name);
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -100,7 +100,7 @@ public class TestSourceFinder
 	private static Collection<Object[]> createCompleteFile(Dialect dialect,
 			String suite, File file, File testRoot, String... extensions)
 	{
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (file.getName().startsWith(".")
 				|| !isNotAcceptedFile(file, Arrays.asList(extensions)))
@@ -157,7 +157,7 @@ public class TestSourceFinder
 	private static Collection<Object[]> createDirectory(Dialect dialect,
 			String suite, File file, String... extensions)
 	{
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (file.getName().startsWith(".")
 				|| !isNotAcceptedFile(file, Arrays.asList(extensions)))
@@ -204,7 +204,7 @@ public class TestSourceFinder
 	{
 		File testRoot = getFile(testRootPath);
 
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -239,7 +239,7 @@ public class TestSourceFinder
 
 	protected static List<String> readFile(File file) throws IOException
 	{
-		List<String> lines = new Vector<String>();
+		List<String> lines = new Vector<>();
 		BufferedReader reader = null;
 
 		try

--- a/core/parser/src/main/java/org/overture/parser/lex/BacktrackInputReader.java
+++ b/core/parser/src/main/java/org/overture/parser/lex/BacktrackInputReader.java
@@ -57,7 +57,7 @@ public class BacktrackInputReader extends Reader
 	private static final char[] EMPTY_DATA = new char[] {};
 
 	/** A stack of position markers for popping. */
-	private Stack<Integer> stack = new Stack<Integer>();
+	private Stack<Integer> stack = new Stack<>();
 
 	/** The characters from the file. */
 	private final char[] data;

--- a/core/parser/src/main/java/org/overture/parser/lex/LatexStreamReader.java
+++ b/core/parser/src/main/java/org/overture/parser/lex/LatexStreamReader.java
@@ -38,7 +38,7 @@ import org.overture.config.Settings;
 
 public class LatexStreamReader extends InputStreamReader
 {
-	private Stack<Boolean> ifstack = new Stack<Boolean>();
+	private Stack<Boolean> ifstack = new Stack<>();
 
 	public LatexStreamReader(InputStream in, String charsetName)
 			throws UnsupportedEncodingException

--- a/core/parser/src/main/java/org/overture/parser/lex/LexTokenReader.java
+++ b/core/parser/src/main/java/org/overture/parser/lex/LexTokenReader.java
@@ -128,7 +128,7 @@ public class LexTokenReader extends BacktrackInputReader
 	}
 
 	/** A stack of Positions for backtracking. */
-	private Stack<Position> stack = new Stack<Position>();
+	private Stack<Position> stack = new Stack<>();
 
 	/** An end of file symbol. */
 	private static final char EOF = (char) -1;
@@ -1205,7 +1205,7 @@ public class LexTokenReader extends BacktrackInputReader
 
 	private List<String> rdName()
 	{
-		List<String> names = new Vector<String>();
+		List<String> names = new Vector<>();
 		names.add(rdIdentifier());
 
 		if (ch == '`')
@@ -1224,7 +1224,7 @@ public class LexTokenReader extends BacktrackInputReader
 
 			if (first.startsWith("mk_") || first.startsWith("is_"))
 			{
-				List<String> one = new Vector<String>();
+				List<String> one = new Vector<>();
 				one.add(first + "`" + names.get(1));
 				names = one;
 			}

--- a/core/parser/src/main/java/org/overture/parser/messages/VDMMessage.java
+++ b/core/parser/src/main/java/org/overture/parser/messages/VDMMessage.java
@@ -38,7 +38,7 @@ public class VDMMessage
 	public final String message;
 	public final ILexLocation location;
 
-	protected List<String> details = new Vector<String>();
+	protected List<String> details = new Vector<>();
 
 	public VDMMessage(int number)
 	{

--- a/core/parser/src/main/java/org/overture/parser/syntax/DefinitionReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/DefinitionReader.java
@@ -680,7 +680,7 @@ public class DefinitionReader extends SyntaxReader
 			throwMessage(2020, "Expecting '(' after function name");
 		}
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new Vector<>();
 
 		while (lastToken().is(VDMToken.BRA))
 		{
@@ -1363,7 +1363,7 @@ public class DefinitionReader extends SyntaxReader
 	private List<String> readTraceIdentifierList() throws ParserException,
 			LexException
 	{
-		List<String> names = new Vector<String>();
+		List<String> names = new Vector<>();
 		names.add(readIdToken("Expecting trace identifier").getName());
 
 		while (lastToken().is(VDMToken.DIVIDE))

--- a/core/parser/src/main/java/org/overture/parser/syntax/ModuleReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/ModuleReader.java
@@ -125,7 +125,7 @@ public class ModuleReader extends SyntaxReader
 
 	public static AFromModuleImports importAll(LexIdentifierToken from)
 	{
-		List<List<PImport>> types = new Vector<List<PImport>>();
+		List<List<PImport>> types = new Vector<>();
 		LexNameToken all = new LexNameToken(from.getName(), "all", from.location);
 		List<PImport> impAll = new Vector<PImport>();
 		impAll.add(AstFactory.newAAllImport(all));
@@ -253,7 +253,7 @@ public class ModuleReader extends SyntaxReader
 		}
 
 		// return new DLModule(name, imports, exports, library);
-		List<ClonableFile> files = new Vector<ClonableFile>();
+		List<ClonableFile> files = new Vector<>();
 		files.add(new ClonableFile(name.location.getFile()));
 
 		AModuleModules module = AstFactory.newAModuleModules(name, imports, exports, null);
@@ -271,7 +271,7 @@ public class ModuleReader extends SyntaxReader
 	private List<List<PExport>> readExportsFromModule() throws ParserException,
 			LexException
 	{
-		List<List<PExport>> types = new Vector<List<PExport>>();
+		List<List<PExport>> types = new Vector<>();
 
 		if (lastToken().is(VDMToken.ALL))
 		{
@@ -436,7 +436,7 @@ public class ModuleReader extends SyntaxReader
 	private List<ILexNameToken> readIdList() throws ParserException,
 			LexException
 	{
-		List<ILexNameToken> list = new Vector<ILexNameToken>();
+		List<ILexNameToken> list = new Vector<>();
 		list.add(readNameToken("Expecting name list"));
 
 		while (ignore(VDMToken.COMMA))
@@ -473,7 +473,7 @@ public class ModuleReader extends SyntaxReader
 	private List<List<PImport>> readImportsFromModule(LexIdentifierToken from)
 			throws ParserException, LexException
 	{
-		List<List<PImport>> types = new Vector<List<PImport>>();
+		List<List<PImport>> types = new Vector<>();
 
 		if (lastToken().is(VDMToken.ALL))
 		{

--- a/core/parser/src/main/java/org/overture/parser/syntax/SyntaxReader.java
+++ b/core/parser/src/main/java/org/overture/parser/syntax/SyntaxReader.java
@@ -69,13 +69,13 @@ public abstract class SyntaxReader
 	protected ClassReader classReader = null;
 
 	/** The errors raised. */
-	private List<VDMError> errors = new Vector<VDMError>();
+	private List<VDMError> errors = new Vector<>();
 
 	/** The warnings raised. */
-	private List<VDMWarning> warnings = new Vector<VDMWarning>();
+	private List<VDMWarning> warnings = new Vector<>();
 
 	/** The sub-readers defined, if any. */
-	private List<SyntaxReader> readers = new Vector<SyntaxReader>();
+	private List<SyntaxReader> readers = new Vector<>();
 
 	/** The maximum number of syntax errors allowed in one Reader. */
 	private static final int MAX = 100;
@@ -616,7 +616,7 @@ public abstract class SyntaxReader
 
 	public List<VDMError> getErrors()
 	{
-		List<VDMError> list = new Vector<VDMError>();
+		List<VDMError> list = new Vector<>();
 
 		for (SyntaxReader rdr : readers)
 		{
@@ -649,7 +649,7 @@ public abstract class SyntaxReader
 
 	public List<VDMWarning> getWarnings()
 	{
-		List<VDMWarning> list = new Vector<VDMWarning>();
+		List<VDMWarning> list = new Vector<>();
 
 		for (SyntaxReader rdr : readers)
 		{

--- a/core/parser/src/main/java/org/overture/parser/util/ParserUtil.java
+++ b/core/parser/src/main/java/org/overture/parser/util/ParserUtil.java
@@ -137,7 +137,7 @@ public class ParserUtil
 		reader = new ClassReader(ltr);
 		result = reader.readClasses();
 
-		return new ParserResult<List<SClassDefinition>>(result, reader.getWarnings(), reader.getErrors());
+		return new ParserResult<>(result, reader.getWarnings(), reader.getErrors());
 	}
 
 	private static LexTokenReader getReader(File file, Dialect dialect,
@@ -173,7 +173,7 @@ public class ParserUtil
 		reader = new ClassReader(ltr);
 		result = reader.readClasses();
 
-		return new ParserResult<List<SClassDefinition>>(result, reader.getWarnings(), reader.getErrors());
+		return new ParserResult<>(result, reader.getWarnings(), reader.getErrors());
 	}
 
 	public static ParserResult<List<AModuleModules>> parseSl(List<File> files)
@@ -223,7 +223,7 @@ public class ParserUtil
 		reader = new ModuleReader(ltr);
 		result = reader.readModules();
 
-		return new ParserResult<List<AModuleModules>>(result, reader.getWarnings(), reader.getErrors());
+		return new ParserResult<>(result, reader.getWarnings(), reader.getErrors());
 	}
 
 	public static ParserResult<List<AModuleModules>> parseSl(String content)
@@ -241,7 +241,7 @@ public class ParserUtil
 		reader = new ModuleReader(ltr);
 		result = reader.readModules();
 
-		return new ParserResult<List<AModuleModules>>(result, reader.getWarnings(), reader.getErrors());
+		return new ParserResult<>(result, reader.getWarnings(), reader.getErrors());
 	}
 
 	public static ParserResult<PExp> parseExpression(String content)

--- a/core/parser/src/test/java/org/overture/parser/tests/framework/BaseParserTestCase.java
+++ b/core/parser/src/test/java/org/overture/parser/tests/framework/BaseParserTestCase.java
@@ -101,11 +101,11 @@ public abstract class BaseParserTestCase<T extends SyntaxReader, R> extends
 
 			System.out.println();
 
-			List<IMessage> warnings = new Vector<IMessage>();
-			List<IMessage> errors = new Vector<IMessage>();
+			List<IMessage> warnings = new Vector<>();
+			List<IMessage> errors = new Vector<>();
 
 			collectParserErrorsAndWarnings(reader, errors, warnings);
-			Result<R> resultFinal = new Result<R>(result, warnings, errors);
+			Result<R> resultFinal = new Result<>(result, warnings, errors);
 
 			if (result instanceof List || result instanceof INode)
 			{

--- a/core/pog/src/main/java/org/overture/pog/contexts/OpBodyEndContext.java
+++ b/core/pog/src/main/java/org/overture/pog/contexts/OpBodyEndContext.java
@@ -21,7 +21,7 @@ public class OpBodyEndContext extends StatefulContext
 			IPogAssistantFactory af)
 	{
 		this.af = af;
-		subs = new LinkedList<Substitution>();
+		subs = new LinkedList<>();
 		for (AInstanceVariableDefinition i : state)
 		{
 			AVariableExp var_exp = new AVariableExp();

--- a/core/pog/src/main/java/org/overture/pog/contexts/OpPostConditionContext.java
+++ b/core/pog/src/main/java/org/overture/pog/contexts/OpPostConditionContext.java
@@ -47,7 +47,7 @@ public class OpPostConditionContext extends StatefulContext implements
 	{
 		super(ctxt);
 		this.gen = ctxt.getGenerator();
-		this.subs = new LinkedList<Substitution>();
+		this.subs = new LinkedList<>();
 		this.forall_exp = getChangedVarsExp(postDef, calledOp);
 		PExp inv = buildInvExp(calledOp, af);
 		this.pred = spellCondition(postDef, af, stm.getArgs(), inv);
@@ -94,7 +94,7 @@ public class OpPostConditionContext extends StatefulContext implements
 		super(ctxt);
 		this.visitor = af.getVarSubVisitor();
 		this.gen = ctxt.getGenerator();
-		this.subs = new LinkedList<Substitution>();
+		this.subs = new LinkedList<>();
 		this.forall_exp = getChangedVarsExp(postDef, calledOp);
 		PExp inv = buildInvExp(calledOp, af);
 		this.pred = spellCondition(postDef, af, exp.getArgs(), inv);
@@ -303,7 +303,7 @@ public class OpPostConditionContext extends StatefulContext implements
 			post_exp = AstExpressionFactory.newAAndBooleanBinaryExp(post_exp, invariant);
 		}
 
-		List<Substitution> subs = new LinkedList<Substitution>();
+		List<Substitution> subs = new LinkedList<>();
 
 		for (int i = 0; i < args.size(); i++)
 		{

--- a/core/pog/src/main/java/org/overture/pog/obligation/OperationCallObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/OperationCallObligation.java
@@ -24,7 +24,7 @@ public class OperationCallObligation extends ProofObligation
 		super(stm, POType.OP_CALL, ctxt, stm.getLocation(), af);
 
 		// cannot quote pre-cond so we spell it out with rewritten arguments
-		List<Substitution> subs = new LinkedList<Substitution>();
+		List<Substitution> subs = new LinkedList<>();
 
 		for (int i = 0; i < stm.getArgs().size(); i++)
 		{

--- a/core/pog/src/main/java/org/overture/pog/obligation/ParameterPatternObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/ParameterPatternObligation.java
@@ -124,7 +124,7 @@ public class ParameterPatternObligation extends ProofObligation
 				List<PMultipleBind> existsBindList = new Vector<PMultipleBind>();
 				PExp existsPredicate = null;
 
-				Set<ILexNameToken> previousBindings = new HashSet<ILexNameToken>();
+				Set<ILexNameToken> previousBindings = new HashSet<>();
 
 				for (PPattern param : paramList)
 				{
@@ -185,7 +185,7 @@ public class ParameterPatternObligation extends ProofObligation
 
 	private List<List<PPattern>> cloneListPatternList(List<List<PPattern>> list)
 	{
-		List<List<PPattern>> r = new LinkedList<List<PPattern>>();
+		List<List<PPattern>> r = new LinkedList<>();
 		for (List<PPattern> list2 : list)
 		{
 			r.add(cloneList(list2));

--- a/core/pog/src/main/java/org/overture/pog/obligation/StateInvariantObligation.java
+++ b/core/pog/src/main/java/org/overture/pog/obligation/StateInvariantObligation.java
@@ -131,7 +131,7 @@ public class StateInvariantObligation extends ProofObligation
 
 		PExp invApplyExpForSub = invApplyExp.clone();
 
-		List<Substitution> subs = new LinkedList<Substitution>();
+		List<Substitution> subs = new LinkedList<>();
 		for (AAssignmentStm asgn : atom.getAssignments())
 		{
 			String hash = asgn.getTarget().apply(af.getStateDesignatorNameGetter());

--- a/core/pog/src/test/java/org/overture/pog/tests/Playground.java
+++ b/core/pog/src/test/java/org/overture/pog/tests/Playground.java
@@ -52,7 +52,7 @@ public class Playground
 		
 		Collection<File> x = FileUtils.listFiles(new File("src/test/resources/adhoc/proj"), new String[]{"vdmpp"}, false);
 		
-		List<File> sources= new LinkedList<File>();
+		List<File> sources= new LinkedList<>();
 		sources.addAll(x);
 		
 		List<INode> ast = ParseTcFacade.typedAstNoRetry(sources, "Playground", Dialect.VDM_PP);

--- a/core/pog/src/test/java/org/overture/pog/tests/newtests/PogAllExamplesTest.java
+++ b/core/pog/src/test/java/org/overture/pog/tests/newtests/PogAllExamplesTest.java
@@ -78,7 +78,7 @@ public class PogAllExamplesTest extends ParamExamplesTest<Boolean>
 	@Override
 	protected List<String> getExamplesToSkip()
 	{
-		LinkedList<String> toSkip = new LinkedList<String>();
+		LinkedList<String> toSkip = new LinkedList<>();
 		toSkip.add("AutomatedStockBrokerPP");
 		
 		return toSkip;

--- a/core/prettyprinting/prettyprinter/src/main/java/org/overture/prettyprinter/TypePrettyPrinterVisitor.java
+++ b/core/prettyprinting/prettyprinter/src/main/java/org/overture/prettyprinter/TypePrettyPrinterVisitor.java
@@ -110,7 +110,7 @@ public class TypePrettyPrinterVisitor extends
 	public String caseAProductType(AProductType node, PrettyPrinterEnv question)
 			throws AnalysisException
 	{
-		List<String> types = new Vector<String>();
+		List<String> types = new Vector<>();
 		for (PType t : node.getTypes())
 		{
 			types.add(t.apply(this, question));
@@ -129,7 +129,7 @@ public class TypePrettyPrinterVisitor extends
 	public String caseAUnionType(AUnionType node, PrettyPrinterEnv question)
 			throws AnalysisException
 	{
-		List<String> types = new Vector<String>();
+		List<String> types = new Vector<>();
 		for (PType t : node.getTypes())
 		{
 			types.add(t.apply(this, question));

--- a/core/testframework/src/main/java/org/overture/test/framework/BaseTestSuite.java
+++ b/core/testframework/src/main/java/org/overture/test/framework/BaseTestSuite.java
@@ -290,7 +290,7 @@ public class BaseTestSuite extends TestSuite
 
 	protected static List<String> readFile(File file) throws IOException
 	{
-		List<String> lines = new Vector<String>();
+		List<String> lines = new Vector<>();
 		BufferedReader reader = null;
 
 		try

--- a/core/testframework/src/main/java/org/overture/test/framework/ResultTestCase.java
+++ b/core/testframework/src/main/java/org/overture/test/framework/ResultTestCase.java
@@ -62,7 +62,7 @@ public abstract class ResultTestCase<R> extends BaseTestCase implements
 			// mrw.save();
 			File resultFile = createResultFile(filename);
 			resultFile.getParentFile().mkdirs();
-			XmlResultReaderWriter<R> xmlResult = new XmlResultReaderWriter<R>(resultFile, this);
+			XmlResultReaderWriter<R> xmlResult = new XmlResultReaderWriter<>(resultFile, this);
 			xmlResult.setResult(this.getClass().getName(), result);
 			try
 			{
@@ -86,7 +86,7 @@ public abstract class ResultTestCase<R> extends BaseTestCase implements
 		assertTrue("Result file " + file.getAbsolutePath() + " does not exist", file.exists());
 
 		// MessageReaderWriter mrw = new MessageReaderWriter(file);
-		XmlResultReaderWriter<R> xmlResult = new XmlResultReaderWriter<R>(file, this);
+		XmlResultReaderWriter<R> xmlResult = new XmlResultReaderWriter<>(file, this);
 		boolean parsed = xmlResult.loadFromXml();
 
 		assertTrue("Could not read result file: " + file.getName(), parsed);
@@ -162,8 +162,8 @@ public abstract class ResultTestCase<R> extends BaseTestCase implements
 	protected <T> Result<T> mergeResults(Set<? extends Result<T>> parse,
 			IResultCombiner<T> c)
 	{
-		List<IMessage> warnings = new Vector<IMessage>();
-		List<IMessage> errors = new Vector<IMessage>();
+		List<IMessage> warnings = new Vector<>();
+		List<IMessage> errors = new Vector<>();
 		T result = null;
 
 		for (Result<T> r : parse)
@@ -172,7 +172,7 @@ public abstract class ResultTestCase<R> extends BaseTestCase implements
 			errors.addAll(r.errors);
 			result = c.combine(result, r.result);
 		}
-		return new Result<T>(result, warnings, errors);
+		return new Result<>(result, warnings, errors);
 	}
 
 }

--- a/core/testframework/src/main/java/org/overture/test/framework/ResultTestCase4.java
+++ b/core/testframework/src/main/java/org/overture/test/framework/ResultTestCase4.java
@@ -58,7 +58,7 @@ public abstract class ResultTestCase4<R> implements IResultStore<R>
 		{
 			File resultFile = createResultFile(filename);
 			resultFile.getParentFile().mkdirs();
-			XmlResultReaderWriter<R> xmlResult = new XmlResultReaderWriter<R>(resultFile, this);
+			XmlResultReaderWriter<R> xmlResult = new XmlResultReaderWriter<>(resultFile, this);
 			xmlResult.setResult(this.getClass().getName(), result);
 			try
 			{
@@ -88,7 +88,7 @@ public abstract class ResultTestCase4<R> implements IResultStore<R>
 				+ " does not exist", file.exists());
 
 		// MessageReaderWriter mrw = new MessageReaderWriter(file);
-		XmlResultReaderWriter<R> xmlResult = new XmlResultReaderWriter<R>(file, this);
+		XmlResultReaderWriter<R> xmlResult = new XmlResultReaderWriter<>(file, this);
 		boolean parsed = xmlResult.loadFromXml();
 
 		Assert.assertTrue("Could not read result file: " + file.getName(), parsed);
@@ -179,8 +179,8 @@ public abstract class ResultTestCase4<R> implements IResultStore<R>
 	protected <T> Result<T> mergeResults(Set<? extends Result<T>> parse,
 			IResultCombiner<T> c)
 	{
-		List<IMessage> warnings = new Vector<IMessage>();
-		List<IMessage> errors = new Vector<IMessage>();
+		List<IMessage> warnings = new Vector<>();
+		List<IMessage> errors = new Vector<>();
 		T result = null;
 
 		for (Result<T> r : parse)
@@ -189,7 +189,7 @@ public abstract class ResultTestCase4<R> implements IResultStore<R>
 			errors.addAll(r.errors);
 			result = c.combine(result, r.result);
 		}
-		return new Result<T>(result, warnings, errors);
+		return new Result<>(result, warnings, errors);
 	}
 
 }

--- a/core/testframework/src/main/java/org/overture/test/util/FileUtils.java
+++ b/core/testframework/src/main/java/org/overture/test/util/FileUtils.java
@@ -40,7 +40,7 @@ public class FileUtils
 		InputStream is = null;
 		BufferedReader br = null;
 		String line;
-		List<String> list = new ArrayList<String>();
+		List<String> list = new ArrayList<>();
 
 		try
 		{
@@ -98,7 +98,7 @@ public class FileUtils
 
 	private static List<String> readTextFromSource(String relativePath)
 	{
-		List<String> list = new ArrayList<String>();
+		List<String> list = new ArrayList<>();
 		try
 		{
 			BufferedReader in = new BufferedReader(new FileReader(new File(new File("."), ("src/test/resources/" + relativePath).replace('/', File.separatorChar))));

--- a/core/testframework/src/main/java/org/overture/test/util/MessageReaderWriter.java
+++ b/core/testframework/src/main/java/org/overture/test/util/MessageReaderWriter.java
@@ -47,8 +47,8 @@ public class MessageReaderWriter
 	public static String ERROR_LABEL = "ERROR";
 	public static String RESULT_LABEL = "RESULT";
 
-	final List<IMessage> errors = new Vector<IMessage>();
-	final List<IMessage> warnings = new Vector<IMessage>();
+	final List<IMessage> errors = new Vector<>();
+	final List<IMessage> warnings = new Vector<>();
 	String result = "";
 	final File file;
 

--- a/core/testframework/src/main/java/org/overture/test/util/XmlResultReaderWriter.java
+++ b/core/testframework/src/main/java/org/overture/test/util/XmlResultReaderWriter.java
@@ -168,8 +168,8 @@ public class XmlResultReaderWriter<R>
 	public boolean loadFromXml()
 	{
 		// File resultFile = new File(file.getAbsoluteFile()+ ".result");
-		List<IMessage> warnings = new Vector<IMessage>();
-		List<IMessage> errors = new Vector<IMessage>();
+		List<IMessage> warnings = new Vector<>();
+		List<IMessage> errors = new Vector<>();
 		R readResult = null;
 
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
@@ -208,7 +208,7 @@ public class XmlResultReaderWriter<R>
 			// doc.getDocumentElement().getChildNodes().getElementsByTagName("result")
 
 			String type = doc.getDocumentElement().getAttributes().getNamedItem("type").getNodeValue();
-			setResult(type, new Result<R>(readResult, warnings, errors));
+			setResult(type, new Result<>(readResult, warnings, errors));
 		} catch (Exception e)
 		{
 			return false;

--- a/core/testing/exsupport/src/main/java/org/overture/core/tests/examples/ExamplePacker.java
+++ b/core/testing/exsupport/src/main/java/org/overture/core/tests/examples/ExamplePacker.java
@@ -69,7 +69,7 @@ class ExamplePacker
 	String name;
 	List<File> sources;
 
-	private List<String> libs = new Vector<String>();
+	private List<String> libs = new Vector<>();
 
 	public ExamplePacker(File root, Dialect dialect)
 	{

--- a/core/testing/exsupport/src/main/java/org/overture/core/tests/examples/ExamplesUtility.java
+++ b/core/testing/exsupport/src/main/java/org/overture/core/tests/examples/ExamplesUtility.java
@@ -116,7 +116,7 @@ abstract public class ExamplesUtility {
 	 */
 	public static Collection<ExampleSourceData> getExamplesSources(
 			String examplesRoot) throws IOException, URISyntaxException {
-		List<ExampleSourceData> r = new LinkedList<ExampleSourceData>();
+		List<ExampleSourceData> r = new LinkedList<>();
 
 		r.addAll(getExamples_(examplesRoot, SL_EXAMPLES_ROOT, Dialect.VDM_SL));
 		r.addAll(getExamples_(examplesRoot, PP_EXAMPLES_ROOT, Dialect.VDM_PP));
@@ -137,7 +137,7 @@ abstract public class ExamplesUtility {
 	 */
 	public static Collection<ExampleSourceData> getLibSources(String libsRoot)
 			throws IOException, URISyntaxException {
-		List<ExampleSourceData> r = new LinkedList<ExampleSourceData>();
+		List<ExampleSourceData> r = new LinkedList<>();
 
 		r.addAll(getLibs_(libsRoot + SL_LIBS_ROOT, Dialect.VDM_SL));
 		r.addAll(getLibs_(libsRoot + PP_LIBS_ROOT, Dialect.VDM_PP));
@@ -150,9 +150,9 @@ abstract public class ExamplesUtility {
 			Dialect dialect) throws IOException, URISyntaxException {
 
 		File dir = new File(libsroot);
-		List<ExampleSourceData> r = new LinkedList<ExampleSourceData>();
+		List<ExampleSourceData> r = new LinkedList<>();
 
-		List<File> libs = new LinkedList<File>();
+		List<File> libs = new LinkedList<>();
 
 		for (File f : dir.listFiles()) {
 			libs.add(f);
@@ -165,12 +165,12 @@ abstract public class ExamplesUtility {
 	private static Collection<ExampleSourceData> getExamples_(
 			String externalsRoot, String examplesRoot, Dialect dialect)
 			throws IOException, URISyntaxException {
-		List<ExampleSourceData> r = new LinkedList<ExampleSourceData>();
+		List<ExampleSourceData> r = new LinkedList<>();
 
 		File dir = new File(externalsRoot + examplesRoot);
 		dir.mkdirs();
 
-		List<File> source = new LinkedList<File>();
+		List<File> source = new LinkedList<>();
 		// grab examples groups
 		for (File f : dir.listFiles()) {
 			// grab example projects
@@ -192,7 +192,7 @@ abstract public class ExamplesUtility {
 					}
 					r.add(new ExampleSourceData(p.getName(), dialect, p
 							.getLanguageVersion(), source));
-					source = new LinkedList<File>();
+					source = new LinkedList<>();
 				}
 			}
 		}

--- a/core/testing/exsupport/src/main/java/org/overture/core/tests/examples/ParamExamplesTest.java
+++ b/core/testing/exsupport/src/main/java/org/overture/core/tests/examples/ParamExamplesTest.java
@@ -167,6 +167,6 @@ public abstract class ParamExamplesTest<R> extends AbsResultTest<R> {
 	 */
 	protected List<String> getExamplesToSkip()
 	{
-		return new LinkedList<String>();
+		return new LinkedList<>();
 	}
 }

--- a/core/testing/extests/src/test/java/org/overture/core/tests/ParseTcAllExamplesTest.java
+++ b/core/testing/extests/src/test/java/org/overture/core/tests/ParseTcAllExamplesTest.java
@@ -39,7 +39,7 @@ public class ParseTcAllExamplesTest
 	@Parameters(name = "{index} : {0}")
 	public static Collection<Object[]> testData() throws IOException, URISyntaxException
 	{
-		Collection<Object[]> r = new Vector<Object[]>();
+		Collection<Object[]> r = new Vector<>();
 
 		Collection<ExampleSourceData> examples = ExamplesUtility.getExamplesSources(EXAMPLES_ROOT);
 

--- a/core/testing/extests/src/test/java/org/overture/core/tests/ParseTcLibsTest.java
+++ b/core/testing/extests/src/test/java/org/overture/core/tests/ParseTcLibsTest.java
@@ -38,7 +38,7 @@ public class ParseTcLibsTest
 	@Parameters(name = "{index} : {0}")
 	public static Collection<Object[]> testData() throws IOException, URISyntaxException
 	{
-		Collection<Object[]> r = new Vector<Object[]>();
+		Collection<Object[]> r = new Vector<>();
 
 		Collection<ExampleSourceData> examples = ExamplesUtility.getLibSources(LIBS_ROOT);
 

--- a/core/testing/extests/src/test/java/org/overture/core/tests/demos/DefNamesTestResult.java
+++ b/core/testing/extests/src/test/java/org/overture/core/tests/demos/DefNamesTestResult.java
@@ -36,7 +36,7 @@ public class DefNamesTestResult {
 
 	public DefNamesTestResult(List<INode> ast, String name) {
 		this.exampleName = name;
-		defNames = new Vector<String>();
+		defNames = new Vector<>();
 		for (INode n : ast) {
 			if (n instanceof AModuleModules) // ModuleModules prints the file
 												// path so we skip it

--- a/core/testing/framework/src/main/java/org/overture/core/tests/ParamExternalsTest.java
+++ b/core/testing/framework/src/main/java/org/overture/core/tests/ParamExternalsTest.java
@@ -77,7 +77,7 @@ public abstract class ParamExternalsTest<R> extends ParamFineGrainTest<R>
 
 		if (external == null)
 		{
-			return new Vector<Object[]>();
+			return new Vector<>();
 		} else
 		{
 			return PathsProvider.computeExternalPaths(external);

--- a/core/testing/framework/src/main/java/org/overture/core/tests/ParseTcFacade.java
+++ b/core/testing/framework/src/main/java/org/overture/core/tests/ParseTcFacade.java
@@ -246,7 +246,7 @@ public abstract class ParseTcFacade
 			ext = parts[1];
 		}
 		File f = new File(sourcePath);
-		List<File> sources = new Vector<File>();
+		List<File> sources = new Vector<>();
 		sources.add(f);
 
 		if (ext.equals("vdmsl") | ext.equals("vdm"))
@@ -258,7 +258,7 @@ public abstract class ParseTcFacade
 		{
 			if (ext.equals("vdmpp") | ext.equals("vpp"))
 			{
-				List<File> files = new Vector<File>();
+				List<File> files = new Vector<>();
 				files.add(f);
 				return parseTcPpContent(files, testName, true);
 
@@ -266,7 +266,7 @@ public abstract class ParseTcFacade
 			{
 				if (ext.equals("vdmrt"))
 				{
-					List<File> files = new Vector<File>();
+					List<File> files = new Vector<>();
 					files.add(f);
 					return parseTcRtContent(files, testName, true);
 				} else

--- a/core/testing/framework/src/main/java/org/overture/core/tests/PathsProvider.java
+++ b/core/testing/framework/src/main/java/org/overture/core/tests/PathsProvider.java
@@ -119,7 +119,7 @@ public class PathsProvider
 	{
 		Collection<File> files = FileUtils.listFiles(dir, new RegexFileFilter(EXTERNAL_VDM_EXTENSION_REGEX), DirectoryFileFilter.DIRECTORY);
 
-		List<Object[]> paths = new Vector<Object[]>();
+		List<Object[]> paths = new Vector<>();
 
 		for (File file : files)
 		{
@@ -155,7 +155,7 @@ public class PathsProvider
 	{
 		Collection<File> files = FileUtils.listFiles(dir, new RegexFileFilter(VDM_EXTENSION_REGEX), DirectoryFileFilter.DIRECTORY);
 
-		List<Object[]> paths = new Vector<Object[]>();
+		List<Object[]> paths = new Vector<>();
 
 		for (File file : files)
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/TypeCheckException.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/TypeCheckException.java
@@ -51,7 +51,7 @@ public class TypeCheckException extends RuntimeException
 	{
 		if (extras == null)
 		{
-			extras = new Vector<TypeCheckException>();
+			extras = new Vector<>();
 		}
 		
 		extras.add(e);

--- a/core/typechecker/src/main/java/org/overture/typechecker/TypeCheckInfo.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/TypeCheckInfo.java
@@ -44,7 +44,7 @@ public class TypeCheckInfo
 	 * context the earlier AnotherQuestion. Other things can be added to the context and it may be used for any purpose.
 	 * It is not used by Overture. (Remove this comment it is starts getting used by overture !)
 	 */
-	private static final Map<Class<?>, Object> context = new HashMap<Class<?>, Object>();
+	private static final Map<Class<?>, Object> context = new HashMap<>();
 
 	public static void clearContext()
 	{
@@ -105,7 +105,7 @@ public class TypeCheckInfo
 			Stack<T> contextStack = lookupListForType(key);
 			if (contextStack == null)
 			{
-				contextStack = new Stack<T>();
+				contextStack = new Stack<>();
 				context.put(key, contextStack);
 			}
 			contextStack.push(value);

--- a/core/typechecker/src/main/java/org/overture/typechecker/TypeChecker.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/TypeChecker.java
@@ -48,14 +48,14 @@ abstract public class TypeChecker
 		void warning(VDMWarning warning);
 	}
 
-	private static List<VDMError> errors = new Vector<VDMError>();
-	private static List<VDMWarning> warnings = new Vector<VDMWarning>();
+	private static List<VDMError> errors = new Vector<>();
+	private static List<VDMWarning> warnings = new Vector<>();
 	private static VDMMessage lastMessage = null;
 	private static final int MAX = 200;
 
 	final protected ITypeCheckerAssistantFactory assistantFactory;
 
-	static List<IStatusListener> listners = new Vector<IStatusListener>();
+	static List<IStatusListener> listners = new Vector<>();
 
 	/**
 	 * VDM-only constructor. <b>NOT</b> for use by extensions.

--- a/core/typechecker/src/main/java/org/overture/typechecker/TypeComparator.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/TypeComparator.java
@@ -68,7 +68,7 @@ public class TypeComparator
 	 * compared without infinite regress.
 	 */
 
-	private static Vector<TypePair> done = new Vector<TypePair>(256);
+	private static Vector<TypePair> done = new Vector<>(256);
 
 	private final ITypeCheckerAssistantFactory assistantFactory;
 

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AExplicitFunctionDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AExplicitFunctionDefinitionAssistantTC.java
@@ -172,7 +172,7 @@ public class AExplicitFunctionDefinitionAssistantTC implements IAstAssistant
 		LexNameToken result = new LexNameToken(d.getName().getModule(), "RESULT", d.getLocation());
 		last.add(AstFactory.newAIdentifierPattern(result));
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new Vector<>();
 
 		if (psize > 1)
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AExplicitOperationDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AExplicitOperationDefinitionAssistantTC.java
@@ -73,7 +73,7 @@ public class AExplicitOperationDefinitionAssistantTC implements IAstAssistant
 			AExplicitOperationDefinition d, Environment base)
 	{
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new Vector<>();
 		List<PPattern> plist = new Vector<PPattern>();
 		plist.addAll((List<PPattern>) d.getParameterPatterns().clone());
 
@@ -120,7 +120,7 @@ public class AExplicitOperationDefinitionAssistantTC implements IAstAssistant
 			AExplicitOperationDefinition d, Environment base)
 	{
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new Vector<>();
 		List<PPattern> plist = new Vector<PPattern>();
 		plist.addAll((List<PPattern>) d.getParameterPatterns().clone());
 
@@ -150,7 +150,7 @@ public class AExplicitOperationDefinitionAssistantTC implements IAstAssistant
 	public List<List<PPattern>> getParamPatternList(
 			AExplicitOperationDefinition func)
 	{
-		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
+		List<List<PPattern>> parameters = new ArrayList<>();
 		List<PPattern> plist = new ArrayList<PPattern>();
 
 		for (PPattern p : func.getParameterPatterns())

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AImplicitFunctionDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AImplicitFunctionDefinitionAssistantTC.java
@@ -122,7 +122,7 @@ public class AImplicitFunctionDefinitionAssistantTC implements IAstAssistant
 			AImplicitFunctionDefinition d)
 	{
 
-		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
+		List<List<PPattern>> parameters = new ArrayList<>();
 		List<PPattern> plist = new ArrayList<PPattern>();
 
 		for (APatternListTypePair pl : d.getParamPatterns())

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AImplicitOperationDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/AImplicitOperationDefinitionAssistantTC.java
@@ -55,7 +55,7 @@ public class AImplicitOperationDefinitionAssistantTC implements IAstAssistant
 			AImplicitOperationDefinition d, Environment base)
 	{
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new Vector<>();
 		List<PPattern> plist = new Vector<PPattern>();
 
 		for (APatternListTypePair pl : (LinkedList<APatternListTypePair>) d.getParameterPatterns())
@@ -103,7 +103,7 @@ public class AImplicitOperationDefinitionAssistantTC implements IAstAssistant
 			AImplicitOperationDefinition d, Environment base)
 	{
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new Vector<>();
 		List<PPattern> plist = new Vector<PPattern>();
 
 		for (APatternListTypePair pl : (LinkedList<APatternListTypePair>) d.getParameterPatterns())
@@ -152,7 +152,7 @@ public class AImplicitOperationDefinitionAssistantTC implements IAstAssistant
 	public List<List<PPattern>> getListParamPatternList(
 			AImplicitOperationDefinition func)
 	{
-		List<List<PPattern>> parameters = new ArrayList<List<PPattern>>();
+		List<List<PPattern>> parameters = new ArrayList<>();
 		List<PPattern> plist = new ArrayList<PPattern>();
 
 		for (APatternListTypePair pl : func.getParameterPatterns())

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/SClassDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/SClassDefinitionAssistantTC.java
@@ -524,7 +524,7 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 		int inheritedThreads = 0;
 		af.createSClassDefinitionAssistant().checkOverloads(c);
 
-		List<List<PDefinition>> superlist = new Vector<List<PDefinition>>();
+		List<List<PDefinition>> superlist = new Vector<>();
 
 		for (PDefinition def : c.getSuperDefs())
 		{
@@ -659,7 +659,7 @@ public class SClassDefinitionAssistantTC implements IAstAssistant
 
 	private void checkOverloads(SClassDefinition c)
 	{
-		List<String> done = new Vector<String>();
+		List<String> done = new Vector<>();
 
 		List<PDefinition> singles = af.createPDefinitionListAssistant().singleDefinitions(c.getDefinitions());
 

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/SFunctionDefinitionAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/definition/SFunctionDefinitionAssistantTC.java
@@ -51,7 +51,7 @@ public class SFunctionDefinitionAssistantTC implements IAstAssistant
 			SFunctionDefinition node, AFunctionType type,
 			List<List<PPattern>> paramPatternList, ILexLocation location)
 	{
-		List<List<PDefinition>> defList = new ArrayList<List<PDefinition>>(); // new Vector<DefinitionList>();
+		List<List<PDefinition>> defList = new ArrayList<>(); // new Vector<DefinitionList>();
 		AFunctionType ftype = type; // Start with the overall function
 		Iterator<List<PPattern>> piter = paramPatternList.iterator();
 

--- a/core/typechecker/src/main/java/org/overture/typechecker/util/LexNameTokenMap.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/util/LexNameTokenMap.java
@@ -39,7 +39,7 @@ public class LexNameTokenMap<V> implements Map<ILexNameToken, V>, Serializable
 	 */
 	private static final long serialVersionUID = -1122692848887584905L;
 
-	private final HashMap<LexNameTokenWrapper, V> map = new HashMap<LexNameTokenWrapper, V>();
+	private final HashMap<LexNameTokenWrapper, V> map = new HashMap<>();
 
 	public V put(ILexNameToken key, V value)
 	{
@@ -57,11 +57,11 @@ public class LexNameTokenMap<V> implements Map<ILexNameToken, V>, Serializable
 
 	public Set<Entry<ILexNameToken, V>> entrySet()
 	{
-		Set<Entry<ILexNameToken, V>> result = new HashSet<Entry<ILexNameToken, V>>();
+		Set<Entry<ILexNameToken, V>> result = new HashSet<>();
 
 		for (Entry<LexNameTokenWrapper, V> lexNameTokenEntry : map.entrySet())
 		{
-			result.add(new LexNameTokenEntry<V>(lexNameTokenEntry));
+			result.add(new LexNameTokenEntry<>(lexNameTokenEntry));
 		}
 
 		return result;
@@ -116,7 +116,7 @@ public class LexNameTokenMap<V> implements Map<ILexNameToken, V>, Serializable
 
 	public Set<ILexNameToken> keySet()
 	{
-		Set<ILexNameToken> result = new HashSet<ILexNameToken>();
+		Set<ILexNameToken> result = new HashSet<>();
 
 		for (LexNameTokenWrapper item : this.map.keySet())
 		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/util/TypeCheckerUtil.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/util/TypeCheckerUtil.java
@@ -285,9 +285,9 @@ public class TypeCheckerUtil
 		{
 			TypeChecker.clearErrors();
 			tc.typeCheck();
-			return new TypeCheckResult<P>(parserResult, parserResult.result, TypeChecker.getWarnings(), TypeChecker.getErrors());
+			return new TypeCheckResult<>(parserResult, parserResult.result, TypeChecker.getWarnings(), TypeChecker.getErrors());
 		}
-		return new TypeCheckResult<P>(parserResult, null, new Vector<VDMWarning>(), new Vector<VDMError>());
+		return new TypeCheckResult<>(parserResult, null, new Vector<>(), new Vector<>());
 	}
 
 }

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/ImplicitDefinitionFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/ImplicitDefinitionFinder.java
@@ -344,7 +344,7 @@ public class ImplicitDefinitionFinder extends QuestionAdaptor<Environment>
 		List<PPattern> params = new Vector<PPattern>();
 		params.add(d.getInitPattern().clone());
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new Vector<>();
 		parameters.add(params);
 
 		PTypeList ptypes = new PTypeList();
@@ -365,7 +365,7 @@ public class ImplicitDefinitionFinder extends QuestionAdaptor<Environment>
 		List<PPattern> params = new Vector<PPattern>();
 		params.add(d.getInvPattern().clone());
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new Vector<>();
 		parameters.add(params);
 
 		PTypeList ptypes = new PTypeList();
@@ -382,7 +382,7 @@ public class ImplicitDefinitionFinder extends QuestionAdaptor<Environment>
 		List<PPattern> params = new Vector<PPattern>();
 		params.add(d.getInvPattern().clone());
 
-		List<List<PPattern>> parameters = new Vector<List<PPattern>>();
+		List<List<PPattern>> parameters = new Vector<>();
 		parameters.add(params);
 
 		PTypeList ptypes = new PTypeList();

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ClassTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ClassTypeFinder.java
@@ -98,7 +98,7 @@ public class ClassTypeFinder extends TypeUnwrapper<AClassType>
 			// class types, making the field types the union of the original
 			// fields' types...
 
-			Map<ILexNameToken, PTypeSet> common = new HashMap<ILexNameToken, PTypeSet>();
+			Map<ILexNameToken, PTypeSet> common = new HashMap<>();
 			Map<ILexNameToken, AAccessSpecifierAccessSpecifier> access = new LexNameTokenMap<AAccessSpecifierAccessSpecifier>();
 
 			// Derive the pseudoclass name for the combined union

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/FunctionTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/FunctionTypeFinder.java
@@ -105,7 +105,7 @@ public class FunctionTypeFinder extends AnswerAdaptor<AFunctionType>
 			type.setFuncType(af.createPTypeAssistant().getFunction(AstFactory.newAUnknownType(type.getLocation())));
 
 			PTypeSet result = new PTypeSet(af);
-			Map<Integer, PTypeSet> params = new HashMap<Integer, PTypeSet>();
+			Map<Integer, PTypeSet> params = new HashMap<>();
 			List<PDefinition> defs = new Vector<PDefinition>();
 
 			for (PType t : type.getTypes())

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/OperationTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/OperationTypeFinder.java
@@ -85,7 +85,7 @@ public class OperationTypeFinder extends TypeUnwrapper<AOperationType>
 			// non static call.
 			type.setOpType(af.createPTypeAssistant().getOperation(AstFactory.newAUnknownType(type.getLocation())));
 			PTypeSet result = new PTypeSet(af);
-			Map<Integer, PTypeSet> params = new HashMap<Integer, PTypeSet>();
+			Map<Integer, PTypeSet> params = new HashMap<>();
 			List<PDefinition> defs = new Vector<PDefinition>();
 
 			for (PType t : type.getTypes())

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ProductExtendedTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/ProductExtendedTypeFinder.java
@@ -105,7 +105,7 @@ public class ProductExtendedTypeFinder extends
 			// Build a N-ary product type, making the types the union of the
 			// original N-ary products' types...
 
-			Map<Integer, PTypeSet> result = new HashMap<Integer, PTypeSet>();
+			Map<Integer, PTypeSet> result = new HashMap<>();
 
 			for (PType t : type.getTypes())
 			{

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordBasisChecker.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordBasisChecker.java
@@ -91,7 +91,7 @@ public class RecordBasisChecker extends TypeUnwrapper<Boolean>
 			// record types, making the field types the union of the original
 			// fields' types...
 
-			Map<String, Vector<PType>> common = new HashMap<String, Vector<PType>>();
+			Map<String, Vector<PType>> common = new HashMap<>();
 			int recordCount = 0;
 
 			for (PType t : type.getTypes())
@@ -122,7 +122,7 @@ public class RecordBasisChecker extends TypeUnwrapper<Boolean>
     		// same size. But if not, the shorter ones have to have UnknownTypes added,
     		// because some of the records do not have that field.
     		
-    		Map<String, PTypeSet> typesets = new HashMap<String, PTypeSet>();
+    		Map<String, PTypeSet> typesets = new HashMap<>();
     		
     		for (String field: common.keySet())
     		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordTypeFinder.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/utilities/type/RecordTypeFinder.java
@@ -87,7 +87,7 @@ public class RecordTypeFinder extends TypeUnwrapper<ARecordInvariantType>
 			// record types, making the field types the union of the original
 			// fields' types...
 
-			Map<String, Vector<PType>> common = new HashMap<String, Vector<PType>>();
+			Map<String, Vector<PType>> common = new HashMap<>();
 			int recordCount = 0;
 
 			for (PType t : type.getTypes())
@@ -120,7 +120,7 @@ public class RecordTypeFinder extends TypeUnwrapper<ARecordInvariantType>
     		// same size. But if not, the shorter ones have to have UnknownTypes added,
     		// because some of the records do not have that field.
     		
-    		Map<String, PTypeSet> typesets = new HashMap<String, PTypeSet>();
+    		Map<String, PTypeSet> typesets = new HashMap<>();
     		
     		for (String field: common.keySet())
     		{

--- a/core/typechecker/src/main/java/org/overture/typechecker/visitor/QualificationVisitor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/visitor/QualificationVisitor.java
@@ -46,7 +46,7 @@ public class QualificationVisitor extends
 	public List<QualifiedDefinition> caseAIsExp(AIsExp node,
 			TypeCheckInfo question) throws AnalysisException
 	{
-		List<QualifiedDefinition> result = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> result = new Vector<>();
 
 		if (node.getTest() instanceof AVariableExp)
 		{
@@ -101,13 +101,13 @@ public class QualificationVisitor extends
 	public List<QualifiedDefinition> createNewReturnValue(INode node,
 			TypeCheckInfo question) throws AnalysisException
 	{
-		return new Vector<QualifiedDefinition>();
+		return new Vector<>();
 	}
 
 	@Override
 	public List<QualifiedDefinition> createNewReturnValue(Object node,
 			TypeCheckInfo question) throws AnalysisException
 	{
-		return new Vector<QualifiedDefinition>();
+		return new Vector<>();
 	}
 }

--- a/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerDefinitionVisitor.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/visitor/TypeCheckerDefinitionVisitor.java
@@ -318,7 +318,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 			local.add(question.assistantFactory.createPDefinitionAssistant().getSelfDefinition(node));
 		}
 
-		List<QualifiedDefinition> qualified = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> qualified = new Vector<>();
 
 		if (node.getPredef() != null)
 		{
@@ -523,7 +523,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 
 		question.assistantFactory.createPDefinitionListAssistant().typeCheck(defs, THIS, new TypeCheckInfo(question.assistantFactory, local, question.scope, question.qualifiers));
 
-		List<QualifiedDefinition> qualified = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> qualified = new Vector<>();
 
 		if (node.getPredef() != null)
 		{
@@ -765,7 +765,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 			}
 		}
 
-		List<QualifiedDefinition> qualified = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> qualified = new Vector<>();
 
 		if (node.getPredef() != null)
 		{
@@ -1008,7 +1008,7 @@ public class TypeCheckerDefinitionVisitor extends AbstractTypeCheckVisitor
 			}
 		}
 
-		List<QualifiedDefinition> qualified = new Vector<QualifiedDefinition>();
+		List<QualifiedDefinition> qualified = new Vector<>();
 
 		if (node.getPredef() != null)
 		{

--- a/core/typechecker/src/test/java/org/overture/typechecker/tests/external/AbstractExternalTest.java
+++ b/core/typechecker/src/test/java/org/overture/typechecker/tests/external/AbstractExternalTest.java
@@ -62,10 +62,10 @@ public abstract class AbstractExternalTest extends CommonTypeCheckerTest
 			tests = TestSourceFinder.createTestCompleteFile(dialect, name, root.getAbsolutePath(), extension);
 		} else
 		{
-			tests = new LinkedList<Object[]>();
+			tests = new LinkedList<>();
 		}
 
-		Collection<Object[]> actualTests = new LinkedList<Object[]>();
+		Collection<Object[]> actualTests = new LinkedList<>();
 		for (Object[] objects : tests)
 		{
 			Object[] temp = objects.clone();

--- a/core/typechecker/src/test/java/org/overture/typechecker/tests/utils/OvertureTestHelper.java
+++ b/core/typechecker/src/test/java/org/overture/typechecker/tests/utils/OvertureTestHelper.java
@@ -48,9 +48,9 @@ public class OvertureTestHelper
 	{
 		if (result.result == null)
 		{
-			return new Result<Boolean>(false, convert(result.parserResult.warnings), convert(result.parserResult.errors));
+			return new Result<>(false, convert(result.parserResult.warnings), convert(result.parserResult.errors));
 		}
-		return new Result<Boolean>(true, convert(result.warnings), convert(result.errors));
+		return new Result<>(true, convert(result.warnings), convert(result.errors));
 	}
 
 	public Result<Boolean> typeCheckSl(File file)
@@ -83,7 +83,7 @@ public class OvertureTestHelper
 
 	public static List<IMessage> convert(List<? extends VDMMessage> messages)
 	{
-		List<IMessage> testMessages = new Vector<IMessage>();
+		List<IMessage> testMessages = new Vector<>();
 
 		for (VDMMessage msg : messages)
 		{

--- a/core/typechecker/src/test/java/org/overture/typechecker/tests/utils/TestSourceFinder.java
+++ b/core/typechecker/src/test/java/org/overture/typechecker/tests/utils/TestSourceFinder.java
@@ -66,7 +66,7 @@ public class TestSourceFinder
 	{
 		File testRoot = getFile(testRootPath.replace('/', File.separatorChar));
 
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -105,7 +105,7 @@ public class TestSourceFinder
 		File testRoot = getFile(testRootPath);
 
 		// TestSuite suite = new TestSourceFinder(name);
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -121,7 +121,7 @@ public class TestSourceFinder
 	private static Collection<Object[]> createCompleteFile(Dialect dialect,
 			String suite, File file, File testRoot, String... extensions)
 	{
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (file.getName().startsWith(".")
 				|| !isNotAcceptedFile(file, Arrays.asList(extensions)))
@@ -178,7 +178,7 @@ public class TestSourceFinder
 	private static Collection<Object[]> createDirectory(Dialect dialect,
 			String suite, File file, String... extensions)
 	{
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (file.getName().startsWith(".")
 				|| !isNotAcceptedFile(file, Arrays.asList(extensions)))
@@ -225,7 +225,7 @@ public class TestSourceFinder
 	{
 		File testRoot = getFile(testRootPath);
 
-		Collection<Object[]> tests = new LinkedList<Object[]>();
+		Collection<Object[]> tests = new LinkedList<>();
 
 		if (testRoot != null && testRoot.exists())
 		{
@@ -260,7 +260,7 @@ public class TestSourceFinder
 
 	protected static List<String> readFile(File file) throws IOException
 	{
-		List<String> lines = new Vector<String>();
+		List<String> lines = new Vector<>();
 		BufferedReader reader = null;
 
 		try


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2293 - “The diamond operator ("<>") should be used ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2293
Please let me know if you have any questions.
Ayman Abdelghany.
