### PR TITLE
The members of an interface declaration or class should appear in a pre-defined order

### DIFF
--- a/core/ast/src/main/java/org/overture/ast/lex/LexBooleanToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexBooleanToken.java
@@ -39,12 +39,6 @@ public class LexBooleanToken extends LexToken implements ILexBooleanToken
 	private static final long serialVersionUID = 1L;
 	public boolean value;
 
-	@Override
-	public boolean getValue()
-	{
-		return value;
-	}
-
 	public LexBooleanToken(VDMToken value, ILexLocation location)
 	{
 		super(location, value);
@@ -55,6 +49,12 @@ public class LexBooleanToken extends LexToken implements ILexBooleanToken
 	{
 		super(location, value ? VDMToken.TRUE : VDMToken.FALSE);
 		this.value = value;
+	}
+
+	@Override
+	public boolean getValue()
+	{
+		return value;
 	}
 
 	@Override

--- a/core/ast/src/main/java/org/overture/ast/lex/LexIdentifierToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexIdentifierToken.java
@@ -39,17 +39,17 @@ public class LexIdentifierToken extends LexToken implements ILexIdentifierToken
 	public final String name;
 	public final boolean old;
 
-	@Override
-	public boolean getOld()
-	{
-		return old;
-	}
-
 	public LexIdentifierToken(String name, boolean old, ILexLocation location)
 	{
 		super(location, VDMToken.IDENTIFIER);
 		this.name = name;
 		this.old = old;
+	}
+
+	@Override
+	public boolean getOld()
+	{
+		return old;
 	}
 
 	public ILexNameToken getClassName()

--- a/core/ast/src/main/java/org/overture/ast/lex/LexLocation.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexLocation.java
@@ -45,15 +45,6 @@ import org.overture.ast.node.ExternalNode;
 
 public class LexLocation implements Serializable, ExternalNode, ILexLocation
 {
-	@Override
-	public LexLocation clone()
-	{
-		LexLocation location = new LexLocation(file, module, startLine, startPos, endLine, endPos, startOffset, endOffset);
-		location.hits = hits;
-		location.executable = executable;
-		return location;
-	}
-
 	public static boolean absoluteToStringLocation = true;
 
 	private static final long serialVersionUID = 1L;
@@ -244,6 +235,15 @@ public class LexLocation implements Serializable, ExternalNode, ILexLocation
 		{
 			return "at " + startLine + ":" + startPos;
 		}
+	}
+
+	@Override
+	public LexLocation clone()
+	{
+		LexLocation location = new LexLocation(file, module, startLine, startPos, endLine, endPos, startOffset, endOffset);
+		location.hits = hits;
+		location.executable = executable;
+		return location;
 	}
 
 	/**

--- a/core/typechecker/src/main/java/org/overture/typechecker/TypeCheckInfo.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/TypeCheckInfo.java
@@ -46,6 +46,47 @@ public class TypeCheckInfo
 	 */
 	private static final Map<Class<?>, Object> context = new HashMap<Class<?>, Object>();
 
+	public final Environment env;
+	public NameScope scope;
+	public LinkedList<PType> qualifiers;
+	public final PType constraint; // expressions
+	public final PType returnType; // statements
+
+	public TypeCheckInfo(ITypeCheckerAssistantFactory assistantFactory,
+						 Environment env, NameScope scope, LinkedList<PType> qualifiers,
+						 PType constraint, PType returnType)
+	{
+		this.assistantFactory = assistantFactory;
+		this.env = env;
+		this.scope = scope;
+		this.qualifiers = qualifiers;
+		this.constraint = constraint;
+		this.returnType = returnType;
+	}
+
+	public TypeCheckInfo(ITypeCheckerAssistantFactory assistantFactory,
+						 Environment env, NameScope scope, LinkedList<PType> qualifiers)
+	{
+		this(assistantFactory, env, scope, qualifiers, null, null);
+	}
+
+	public TypeCheckInfo(ITypeCheckerAssistantFactory assistantFactory,
+						 Environment env, NameScope scope)
+	{
+		this(assistantFactory, env, scope, null, null, null);
+	}
+
+	public TypeCheckInfo(ITypeCheckerAssistantFactory assistantFactory,
+						 Environment env)
+	{
+		this(assistantFactory, env, null, null, null, null);
+	}
+
+	public TypeCheckInfo()
+	{
+		this(null, null, null, null, null, null);
+	}
+
 	public static void clearContext()
 	{
 		context.clear();
@@ -130,47 +171,6 @@ public class TypeCheckInfo
 			}
 		}
 		return null;
-	}
-
-	public final Environment env;
-	public NameScope scope;
-	public LinkedList<PType> qualifiers;
-	public final PType constraint; // expressions
-	public final PType returnType; // statements
-
-	public TypeCheckInfo(ITypeCheckerAssistantFactory assistantFactory,
-			Environment env, NameScope scope, LinkedList<PType> qualifiers,
-			PType constraint, PType returnType)
-	{
-		this.assistantFactory = assistantFactory;
-		this.env = env;
-		this.scope = scope;
-		this.qualifiers = qualifiers;
-		this.constraint = constraint;
-		this.returnType = returnType;
-	}
-
-	public TypeCheckInfo(ITypeCheckerAssistantFactory assistantFactory,
-			Environment env, NameScope scope, LinkedList<PType> qualifiers)
-	{
-		this(assistantFactory, env, scope, qualifiers, null, null);
-	}
-
-	public TypeCheckInfo(ITypeCheckerAssistantFactory assistantFactory,
-			Environment env, NameScope scope)
-	{
-		this(assistantFactory, env, scope, null, null, null);
-	}
-
-	public TypeCheckInfo(ITypeCheckerAssistantFactory assistantFactory,
-			Environment env)
-	{
-		this(assistantFactory, env, null, null, null, null);
-	}
-
-	public TypeCheckInfo()
-	{
-		this(null, null, null, null, null, null);
 	}
 
 	@Override

--- a/ide/core/src/main/java/org/overture/ide/internal/core/ast/VdmModelManager.java
+++ b/ide/core/src/main/java/org/overture/ide/internal/core/ast/VdmModelManager.java
@@ -34,16 +34,16 @@ import org.overture.ide.core.resources.IVdmProject;
 public class VdmModelManager implements IVdmModelManager
 {
 	Map<IVdmProject, Map<String, IVdmModel>> asts;
-
-	protected VdmModelManager()
-	{
-		asts = new HashMap<IVdmProject, Map<String, IVdmModel>>();
-	}
-
+	
 	/**
 	 * A handle to the unique Singleton instance.
 	 */
 	static private volatile VdmModelManager _instance = null;
+	
+	protected VdmModelManager()
+	{
+		asts = new HashMap<IVdmProject, Map<String, IVdmModel>>();
+	}
 
 	/**
 	 * @return The unique instance of this class.

--- a/ide/debug/src/main/java/org/overture/ide/debug/core/dbgp/internal/DbgpDebugingEngine.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/core/dbgp/internal/DbgpDebugingEngine.java
@@ -60,6 +60,8 @@ public class DbgpDebugingEngine extends DbgpTermination implements
 	// FIXME [OutOfMemory]
 	private static boolean outOfMemory = false;
 
+	private final ListenerList listeners = new ListenerList();
+
 	public DbgpDebugingEngine(Socket socket) throws IOException
 	{
 		this.socket = socket;
@@ -183,8 +185,6 @@ public class DbgpDebugingEngine extends DbgpTermination implements
 
 		fireObjectTerminated(e);
 	}
-
-	private final ListenerList listeners = new ListenerList();
 
 	protected void firePacketReceived(IDbgpRawPacket content)
 	{

--- a/ide/debug/src/main/java/org/overture/ide/debug/core/dbgp/internal/utils/DbgpXmlEntityParser.java
+++ b/ide/debug/src/main/java/org/overture/ide/debug/core/dbgp/internal/utils/DbgpXmlEntityParser.java
@@ -63,18 +63,65 @@ public class DbgpXmlEntityParser extends DbgpXmlParser
 
 	public static final String TAG_PROPERTY = "property"; //$NON-NLS-1$
 
-	protected DbgpXmlEntityParser()
-	{
-
-	}
-
 	private static final String ATTR_LEVEL = "level"; //$NON-NLS-1$
 	private static final String ATTR_CMDBEGIN = "cmdbegin"; //$NON-NLS-1$
 	private static final String ATTR_CMDEND = "cmdend"; //$NON-NLS-1$
 	private static final String ATTR_LINENO = "lineno"; //$NON-NLS-1$
 	private static final String ATTR_FILENAME = "filename"; //$NON-NLS-1$
 	private static final String ATTR_WHERE = "where"; //$NON-NLS-1$
+	private static final String FILE_SCHEME_PREFIX = IDebugConstants.FILE_SCHEME
+			+ ":///"; //$NON-NLS-1$
+			
+	private static final String ATTR_NAME = "name"; //$NON-NLS-1$
+	private static final String ATTR_FULLNAME = "fullname"; //$NON-NLS-1$
+	private static final String ATTR_TYPE = "type"; //$NON-NLS-1$
+	private static final String ATTR_CHILDREN = "children"; //$NON-NLS-1$
+	private static final String ATTR_NUMCHILDREN = "numchildren"; //$NON-NLS-1$
+	private static final String ATTR_CONSTANT = "constant"; //$NON-NLS-1$
+	private static final String ATTR_KEY = "key"; //$NON-NLS-1$
+	private static final String ATTR_PAGE = "page"; //$NON-NLS-1$
+	private static final String ATTR_PAGE_SIZE = "pagesize"; //$NON-NLS-1$
+	private static final String ATTR_ADDRESS = "address"; //$NON-NLS-1$
 
+	private static final String ATTR_REASON = "reason"; //$NON-NLS-1$
+	private static final String ATTR_STATUS = "status"; //$NON-NLS-1$
+
+	private static final String ELEM_INTERNAL = "internal";
+	private static final String ATTR_THREAD_ID = "threadId";
+	private static final String ATTR_THREAD_NAME = "threadName";
+	private static final String ATTR_THREAD_STATE = "threadState";
+
+	private static final String LINE_BREAKPOINT = "line"; //$NON-NLS-1$
+	private static final String CALL_BREAKPOINT = "call"; //$NON-NLS-1$
+	private static final String RETURN_BREAKPOINT = "return"; //$NON-NLS-1$
+	private static final String EXCEPTION_BREAKPOINT = "exception"; //$NON-NLS-1$
+	private static final String CONDITIONAL_BREAKPOINT = "conditional"; //$NON-NLS-1$
+	private static final String WATCH_BREAKPOINT = "watch"; //$NON-NLS-1$
+
+	private static final String ATTR_ID = "id"; //$NON-NLS-1$
+	private static final String ATTR_STATE = "state"; //$NON-NLS-1$
+	private static final String ATTR_HIT_COUNT = "hit_count"; //$NON-NLS-1$
+	private static final String ATTR_HIT_VALUE = "hit_value"; //$NON-NLS-1$
+	private static final String ATTR_HIT_CONDITION = "hit_condition"; //$NON-NLS-1$
+	private static final String ATTR_LINE = "line"; //$NON-NLS-1$
+	private static final String ATTR_FUNCTION = "function"; //$NON-NLS-1$
+	private static final String ATTR_EXCEPTION = "exception"; //$NON-NLS-1$
+	private static final String ATTR_EXPRESSION = "expression"; //$NON-NLS-1$
+
+	private static final String ATTR_APPID = "appid"; //$NON-NLS-1$
+	private static final String ATTR_IDEKEY = "idekey"; //$NON-NLS-1$
+	private static final String ATTR_SESSION = "session"; //$NON-NLS-1$
+	private static final String ATTR_THREAD = "thread"; //$NON-NLS-1$
+	private static final String ATTR_PARENT = "parent"; //$NON-NLS-1$
+	private static final String ATTR_LANGUAGE = "language"; //$NON-NLS-1$
+
+	private static final String ATTR_ENCODING = "encoding"; //$NON-NLS-1$
+	
+	protected DbgpXmlEntityParser()
+	{
+
+	}
+	
 	public static DbgpStackLevel parseStackLevel(Element element)
 			throws DbgpException
 	{
@@ -107,9 +154,6 @@ public class DbgpXmlEntityParser extends DbgpXmlParser
 
 		return new DbgpStackLevel(fileUri, where, level, lineNumber, beginLine, beginColumn, endLine, endColumn);
 	}
-
-	private static final String FILE_SCHEME_PREFIX = IDebugConstants.FILE_SCHEME
-			+ ":///"; //$NON-NLS-1$
 
 	private static URI parseURI(String fileName)
 	{
@@ -170,17 +214,6 @@ public class DbgpXmlEntityParser extends DbgpXmlParser
 		String value = parseContent(element);
 		return new DbgpFeature(supported, name, value);
 	}
-
-	private static final String ATTR_NAME = "name"; //$NON-NLS-1$
-	private static final String ATTR_FULLNAME = "fullname"; //$NON-NLS-1$
-	private static final String ATTR_TYPE = "type"; //$NON-NLS-1$
-	private static final String ATTR_CHILDREN = "children"; //$NON-NLS-1$
-	private static final String ATTR_NUMCHILDREN = "numchildren"; //$NON-NLS-1$
-	private static final String ATTR_CONSTANT = "constant"; //$NON-NLS-1$
-	private static final String ATTR_KEY = "key"; //$NON-NLS-1$
-	private static final String ATTR_PAGE = "page"; //$NON-NLS-1$
-	private static final String ATTR_PAGE_SIZE = "pagesize"; //$NON-NLS-1$
-	private static final String ATTR_ADDRESS = "address"; //$NON-NLS-1$
 
 	public static IDbgpProperty parseProperty(Element property)
 	{
@@ -283,14 +316,6 @@ public class DbgpXmlEntityParser extends DbgpXmlParser
 		return new DbgpProperty(name, fullName, type, value, childrenCount, hasChildren, constant, key, address, availableChildren, page, pagesize);
 	}
 
-	private static final String ATTR_REASON = "reason"; //$NON-NLS-1$
-	private static final String ATTR_STATUS = "status"; //$NON-NLS-1$
-
-	private static final String ELEM_INTERNAL = "internal";
-	private static final String ATTR_THREAD_ID = "threadId";
-	private static final String ATTR_THREAD_NAME = "threadName";
-	private static final String ATTR_THREAD_STATE = "threadState";
-
 	public static IDbgpStatus parseStatus(Element element)
 			throws DbgpProtocolException
 	{
@@ -315,23 +340,6 @@ public class DbgpXmlEntityParser extends DbgpXmlParser
 
 		return DbgpStatus.parse(status, reason, interpreterThreadState);
 	}
-
-	private static final String LINE_BREAKPOINT = "line"; //$NON-NLS-1$
-	private static final String CALL_BREAKPOINT = "call"; //$NON-NLS-1$
-	private static final String RETURN_BREAKPOINT = "return"; //$NON-NLS-1$
-	private static final String EXCEPTION_BREAKPOINT = "exception"; //$NON-NLS-1$
-	private static final String CONDITIONAL_BREAKPOINT = "conditional"; //$NON-NLS-1$
-	private static final String WATCH_BREAKPOINT = "watch"; //$NON-NLS-1$
-
-	private static final String ATTR_ID = "id"; //$NON-NLS-1$
-	private static final String ATTR_STATE = "state"; //$NON-NLS-1$
-	private static final String ATTR_HIT_COUNT = "hit_count"; //$NON-NLS-1$
-	private static final String ATTR_HIT_VALUE = "hit_value"; //$NON-NLS-1$
-	private static final String ATTR_HIT_CONDITION = "hit_condition"; //$NON-NLS-1$
-	private static final String ATTR_LINE = "line"; //$NON-NLS-1$
-	private static final String ATTR_FUNCTION = "function"; //$NON-NLS-1$
-	private static final String ATTR_EXCEPTION = "exception"; //$NON-NLS-1$
-	private static final String ATTR_EXPRESSION = "expression"; //$NON-NLS-1$
 
 	private static List<Element> getChildElements(Element node)
 
@@ -425,13 +433,6 @@ public class DbgpXmlEntityParser extends DbgpXmlParser
 		return null;
 	}
 
-	private static final String ATTR_APPID = "appid"; //$NON-NLS-1$
-	private static final String ATTR_IDEKEY = "idekey"; //$NON-NLS-1$
-	private static final String ATTR_SESSION = "session"; //$NON-NLS-1$
-	private static final String ATTR_THREAD = "thread"; //$NON-NLS-1$
-	private static final String ATTR_PARENT = "parent"; //$NON-NLS-1$
-	private static final String ATTR_LANGUAGE = "language"; //$NON-NLS-1$
-
 	public static IDbgpSessionInfo parseSession(Element element)
 	{
 		String appId = element.getAttribute(ATTR_APPID);
@@ -459,8 +460,6 @@ public class DbgpXmlEntityParser extends DbgpXmlParser
 		 */
 		return getEncodedValue((Element) list.item(0));
 	}
-
-	private static final String ATTR_ENCODING = "encoding"; //$NON-NLS-1$
 
 	protected static String getEncodedValue(Element element)
 	{


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1213 - “The members of an interface declaration or class should appear in a pre-defined order”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
Ayman Abdelghany.