### PR TITLE
Useless parentheses around expressions should be removed

### DIFF
--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/Tuple.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/Tuple.java
@@ -96,7 +96,7 @@ public class Tuple implements ValueType, Comparable
 
 			if(toValue instanceof VDMSeq && type == String.class)
 			{
-				for(Object c : ((VDMSeq) toValue))
+				for(Object c : (VDMSeq) toValue)
 				{
 					if(!(c instanceof Character))
 					{
@@ -112,7 +112,7 @@ public class Tuple implements ValueType, Comparable
 				return true;
 			}
 			
-			if (toValue != null && !(type.isInstance(toValue)))
+			if (toValue != null && !type.isInstance(toValue))
 			{
 				return false;
 			}

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/copying/FastByteArrayInputStream.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/copying/FastByteArrayInputStream.java
@@ -30,15 +30,15 @@ public class FastByteArrayInputStream extends InputStream {
     }
 
     public final int read() {
-        return (pos < count) ? (buf[pos++] & 0xff) : -1;
+        return pos < count ? (buf[pos++] & 0xff) : -1;
     }
 
     public final int read(byte[] b, int off, int len) {
         if (pos >= count)
             return -1;
 
-        if ((pos + len) > count)
-            len = (count - pos);
+        if (pos + len > count)
+            len = count - pos;
 
         System.arraycopy(buf, pos, b, off, len);
         pos += len;
@@ -46,7 +46,7 @@ public class FastByteArrayInputStream extends InputStream {
     }
 
     public final long skip(long n) {
-        if ((pos + n) > count)
+        if (pos + n > count)
             n = count - pos;
         if (n < 0)
             return 0;

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCallStmToStringBuilder.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCallStmToStringBuilder.java
@@ -100,7 +100,7 @@ public class JavaCallStmToStringBuilder extends JavaClassCreatorBase implements 
 			
 			if(arg instanceof AIdentifierVarExpIR && idConstNameMap.containsKey(((AIdentifierVarExpIR) arg).getName()))
 			{
-				AIdentifierVarExpIR idVarExp = ((AIdentifierVarExpIR) arg);
+				AIdentifierVarExpIR idVarExp = (AIdentifierVarExpIR) arg;
 				if(Settings.dialect != Dialect.VDM_SL)
 				{
 					utilsToStrCall.getArgs().add(storeAssistant.consStoreLookup(idVarExp, true));

--- a/core/codegen/platform/src/main/java/org/overture/codegen/assistant/PatternAssistantIR.java
+++ b/core/codegen/platform/src/main/java/org/overture/codegen/assistant/PatternAssistantIR.java
@@ -32,7 +32,7 @@ public class PatternAssistantIR  extends AssistantBase
 		{
 			if (nextType instanceof ATupleTypeIR)
 			{
-				ATupleTypeIR nextTupleType = ((ATupleTypeIR) nextType);
+				ATupleTypeIR nextTupleType = (ATupleTypeIR) nextType;
 
 				if (nextTupleType.getTypes().size() == tuplePattern.getPatterns().size())
 				{

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/predgen/TypePredHandler.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/predgen/TypePredHandler.java
@@ -277,7 +277,7 @@ public class TypePredHandler
 			return null;
 		}
 		
-		SVarExpIR var = ((SVarExpIR) col);
+		SVarExpIR var = (SVarExpIR) col;
 		
 		if (varMayBeNull(var.getType()))
 		{

--- a/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/predgen/TypePredUtil.java
+++ b/core/codegen/vdm2jml/src/main/java/org/overture/codegen/vdm2jml/predgen/TypePredUtil.java
@@ -297,7 +297,7 @@ public class TypePredUtil
 			}
 			else if(type instanceof ASeqSeqTypeIR)
 			{
-				ASeqSeqTypeIR seqType = ((ASeqSeqTypeIR) type);
+				ASeqSeqTypeIR seqType = (ASeqSeqTypeIR) type;
 				STypeIR elementType = seqType.getSeqOf();
 				
 				return new SeqInfo(assist.isOptional(seqType), findTypeInfo(elementType), BooleanUtils.isTrue(seqType.getSeq1()));

--- a/core/typechecker/src/main/java/org/overture/typechecker/assistant/type/AFunctionTypeAssistantTC.java
+++ b/core/typechecker/src/main/java/org/overture/typechecker/assistant/type/AFunctionTypeAssistantTC.java
@@ -73,7 +73,7 @@ public class AFunctionTypeAssistantTC implements IAstAssistant
 		if (isCurried && type.getResult() instanceof AFunctionType)
 		{
 			AFunctionType ft = (AFunctionType) type.getResult().clone();
-			AFunctionType t = AstFactory.newAFunctionType(type.getLocation(), false, ((List<PType>) type.getParameters().clone()), getCurriedPostType(ft, isCurried));
+			AFunctionType t = AstFactory.newAFunctionType(type.getLocation(), false, (List<PType>) type.getParameters().clone(), getCurriedPostType(ft, isCurried));
 			t.setDefinitions(type.getDefinitions());
 			t.setInstantiated(null);
 			return t;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck - “ Useless parentheses around expressions should be removed to prevent any misunderstanding ”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
Please let me know if you have any questions.
Ayman Abdelghany.
