### PR TITLE
String literals should not be duplicated

### DIFF
--- a/core/ast/src/main/java/org/overture/ast/lex/LexNameToken.java
+++ b/core/ast/src/main/java/org/overture/ast/lex/LexNameToken.java
@@ -43,6 +43,8 @@ public class LexNameToken extends LexToken implements ILexNameToken,
 		Serializable
 {
 	private static final long serialVersionUID = 1L;
+	public static final String CLASS = "CLASS";
+	public static final String THREAD = "thread";
 
 	public final String module;
 	public final String name;
@@ -177,7 +179,7 @@ public class LexNameToken extends LexToken implements ILexNameToken,
 
 	public LexNameToken getSelfName()
 	{
-		if (module.equals("CLASS"))
+		if (module.equals(CLASS))
 		{
 			return new LexNameToken(name, "self", location);
 		} else
@@ -188,15 +190,15 @@ public class LexNameToken extends LexToken implements ILexNameToken,
 
 	public LexNameToken getThreadName()
 	{
-		if (module.equals("CLASS"))
+		if (module.equals(CLASS))
 		{
-			LexNameToken thread = new LexNameToken(name, "thread", location);
+			LexNameToken thread = new LexNameToken(name, THREAD, location);
 			thread.setTypeQualifier(new Vector<PType>());
 			return thread;
 		}
 		else
 		{
-			LexNameToken thread = new LexNameToken(module, "thread", location);
+			LexNameToken thread = new LexNameToken(module, THREAD, location);
 			thread.setTypeQualifier(new Vector<PType>());
 			return thread;
 		}
@@ -204,7 +206,7 @@ public class LexNameToken extends LexToken implements ILexNameToken,
 
 	public LexNameToken getThreadName(ILexLocation loc)
 	{
-		LexNameToken thread = new LexNameToken(loc.getModule(), "thread", loc);
+		LexNameToken thread = new LexNameToken(loc.getModule(), THREAD, loc);
 		thread.setTypeQualifier(new Vector<PType>());
 		return thread;
 	}
@@ -216,7 +218,7 @@ public class LexNameToken extends LexToken implements ILexNameToken,
 
 	public LexNameToken getClassName()
 	{
-		return new LexNameToken("CLASS", name, location);
+		return new LexNameToken(CLASS, name, location);
 	}
 
 	public void setTypeQualifier(List<PType> types)

--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/SeqUtil.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/SeqUtil.java
@@ -25,6 +25,9 @@ import java.util.Collections;
 
 public class SeqUtil
 {
+
+	public static final String CANNOT_MODIFY_SEQUENCE_FROM_NULL = "Cannot modify sequence from null";
+
 	public static VDMSeq seq()
 	{
 		return new VDMSeq();
@@ -48,13 +51,13 @@ public class SeqUtil
 	{
 		if(map == null)
 		{
-			throw new IllegalArgumentException("Cannot modify sequence from null");
+			throw new IllegalArgumentException(CANNOT_MODIFY_SEQUENCE_FROM_NULL);
 		}
 		
 		Maplet[] maplets = MapUtil.toMaplets(map);
 		
 		if(maplets == null)
-			throw new IllegalArgumentException("Cannot modify sequence from null");
+			throw new IllegalArgumentException(CANNOT_MODIFY_SEQUENCE_FROM_NULL);
 		
 		if(seq == null)
 			throw new IllegalArgumentException("Cannot modify null");
@@ -78,13 +81,13 @@ public class SeqUtil
 	{
 		if(map == null)
 		{
-			throw new IllegalArgumentException("Cannot modify sequence from null");
+			throw new IllegalArgumentException(CANNOT_MODIFY_SEQUENCE_FROM_NULL);
 		}
 		
 		Maplet[] maplets = MapUtil.toMaplets(map);
 		
 		if(maplets == null)
-			throw new IllegalArgumentException("Cannot modify sequence from null");
+			throw new IllegalArgumentException(CANNOT_MODIFY_SEQUENCE_FROM_NULL);
 
 		if(string == null)
 			throw new IllegalArgumentException("Cannot modify null");

--- a/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenMain.java
+++ b/core/codegen/javagen/src/main/java/org/overture/codegen/vdm2java/JavaCodeGenMain.java
@@ -68,11 +68,12 @@ public class JavaCodeGenMain
 	public static final String SEP_TEST_CODE = "-separate";
 	public static final String VDM_LOC = "-vdmloc";
 	public static final String NO_CLONING = "-nocloning";
-	
+
 	// Folder names
 	private static final String GEN_MODEL_CODE_FOLDER = "main";
 	private static final String GEN_TESTS_FOLDER = "test";
-	
+	public static final String COULD_NOT_CODE_GENERATE_MODEL = "Could not code generate model: ";
+
 	public static void main(String[] args)
 	{
 		Settings.release = Release.VDM_10;
@@ -318,7 +319,7 @@ public class JavaCodeGenMain
 			}
 		} catch (AnalysisException e)
 		{
-			Logger.getLog().println("Could not code generate model: "
+			Logger.getLog().println(COULD_NOT_CODE_GENERATE_MODEL
 					+ e.getMessage());
 
 		}
@@ -349,7 +350,7 @@ public class JavaCodeGenMain
 
 		} catch (AnalysisException e)
 		{
-			Logger.getLog().println("Could not code generate model: "
+			Logger.getLog().println(COULD_NOT_CODE_GENERATE_MODEL
 					+ e.getMessage());
 		}
 	}
@@ -386,7 +387,7 @@ public class JavaCodeGenMain
 
 		} catch (AnalysisException e)
 		{
-			Logger.getLog().println("Could not code generate model: "
+			Logger.getLog().println(COULD_NOT_CODE_GENERATE_MODEL
 					+ e.getMessage());
 
 		}

--- a/core/codegen/vdm2jml-runtime/src/main/java/org/overture/codegen/vdm2jml/runtime/V2J.java
+++ b/core/codegen/vdm2jml-runtime/src/main/java/org/overture/codegen/vdm2jml/runtime/V2J.java
@@ -17,7 +17,10 @@ import org.overture.codegen.runtime.VDMSet;
  */
 public class V2J
 {
-    /*@ pure @*/
+
+	public static final String METHOD_IS_ONLY_SUPPORTED_FOR = "Method is only supported for ";
+
+	/*@ pure @*/
     /*@ helper @*/
 	public static boolean isMap(Object subject)
 	{
@@ -95,7 +98,7 @@ public class V2J
 			return tuple.get(fieldNo);
 		} else
 		{
-			throw new IllegalArgumentException("Method is only supported for " + Tuple.class);
+			throw new IllegalArgumentException(METHOD_IS_ONLY_SUPPORTED_FOR + Tuple.class);
 		}
 	}
 	
@@ -115,7 +118,7 @@ public class V2J
 			return seq.get(index);
 		}
 
-		throw new IllegalArgumentException("Method is only supported for " + VDMSeq.class + " and " + VDMSet.class);
+		throw new IllegalArgumentException(METHOD_IS_ONLY_SUPPORTED_FOR + VDMSeq.class + " and " + VDMSet.class);
 	}
 	
     /*@ pure @*/
@@ -134,7 +137,7 @@ public class V2J
 			return seq.get(index);
 		}
 
-		throw new IllegalArgumentException("Method is only supported for " + VDMMap.class);
+		throw new IllegalArgumentException(METHOD_IS_ONLY_SUPPORTED_FOR + VDMMap.class);
 	}
 	
     /*@ pure @*/
@@ -152,7 +155,7 @@ public class V2J
 			return seq.get(index);
 		}
 
-		throw new IllegalArgumentException("Method is only supported for " + VDMMap.class);
+		throw new IllegalArgumentException(METHOD_IS_ONLY_SUPPORTED_FOR + VDMMap.class);
 	}
 	
     /*@ pure @*/
@@ -175,7 +178,7 @@ public class V2J
 			return map.size();
 		}
 
-		throw new IllegalArgumentException("Method is only supported for " + Collection.class + " and " + VDMMap.class);
+		throw new IllegalArgumentException(METHOD_IS_ONLY_SUPPORTED_FOR + Collection.class + " and " + VDMMap.class);
 	}
 
     /*@ pure @*/
@@ -191,6 +194,6 @@ public class V2J
 			return seq;
 		}
 
-		throw new IllegalArgumentException("Method is only supported for " + VDMSet.class);
+		throw new IllegalArgumentException(METHOD_IS_ONLY_SUPPORTED_FOR + VDMSet.class);
 	}
 }

--- a/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceRunnerMain.java
+++ b/core/combinatorialtesting/ctruntime/src/main/java/org/overture/ct/ctruntime/TraceRunnerMain.java
@@ -64,6 +64,8 @@ import org.overture.util.Base64;
 
 public class TraceRunnerMain implements IProgressMonitor
 {
+	public static final String INITIALIZATION = "Initialization: ";
+	public static final String UTF_8 = "UTF-8";
 	public static boolean USE_SYSTEM_EXIT = true;
 	private final static boolean DEBUG = false;
 	
@@ -524,20 +526,20 @@ public class TraceRunnerMain implements IProgressMonitor
 					exit(0);
 				} catch (ContextException e)
 				{
-					System.err.println("Initialization: " + e);
+					System.err.println(INITIALIZATION + e);
 					e.ctxt.printStackTrace(Console.out, true);
 					RTLogger.dump(true);
 					exit(3);
 				} catch (ValueException e)
 				{
-					System.err.println("Initialization: " + e);
+					System.err.println(INITIALIZATION + e);
 					e.ctxt.printStackTrace(Console.out, true);
 					RTLogger.dump(true);
 					exit(3);
 				} catch (Exception e)
 
 				{
-					System.err.println("Initialization: " + e);
+					System.err.println(INITIALIZATION + e);
 					e.printStackTrace();
 					RTLogger.dump(true);
 					exit(3);
@@ -835,9 +837,9 @@ public class TraceRunnerMain implements IProgressMonitor
 			System.err.println("Socket to IDE not valid.");
 			return;
 		}
-		byte[] header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>".getBytes("UTF-8");
-		byte[] body = data.toString().getBytes("UTF-8");
-		byte[] size = Integer.toString(header.length + body.length).getBytes("UTF-8");
+		byte[] header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>".getBytes(UTF_8);
+		byte[] body = data.toString().getBytes(UTF_8);
+		byte[] size = Integer.toString(header.length + body.length).getBytes(UTF_8);
 
 		output.write(size);
 		output.write(separator);

--- a/core/interpreter/src/main/java/org/overture/interpreter/VDMPP.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/VDMPP.java
@@ -62,6 +62,7 @@ import org.overture.typechecker.TypeChecker;
 
 public class VDMPP extends VDMJ
 {
+	public static final String CLASS = "class";
 	protected ClassListInterpreter classes = new ClassListInterpreter();
 
 	public VDMPP()
@@ -116,7 +117,7 @@ public class VDMPP extends VDMJ
 					classes.addAll(loaded);
 					classes.remap();
 
-					infoln("Loaded " + plural(loaded.size(), "class", "es")
+					infoln("Loaded " + plural(loaded.size(), CLASS, "es")
 							+ " from " + file + " in " + (double) (end - begin)
 							/ 1000 + " secs");
 				} else
@@ -155,7 +156,7 @@ public class VDMPP extends VDMJ
 
 		if (n > 0)
 		{
-			info("Parsed " + plural(n, "class", "es") + " in "
+			info("Parsed " + plural(n, CLASS, "es") + " in "
 					+ (double) duration / 1000 + " secs. ");
 			info(perrs == 0 ? "No syntax errors" : "Found "
 					+ plural(perrs, "syntax error", "s"));
@@ -214,7 +215,7 @@ public class VDMPP extends VDMJ
 
 		if (n > 0)
 		{
-			info("Type checked " + plural(n, "class", "es") + " in "
+			info("Type checked " + plural(n, CLASS, "es") + " in "
 					+ (double) (after - before) / 1000 + " secs. ");
 			info(terrs == 0 ? "No type errors" : "Found "
 					+ plural(terrs, "type error", "s"));
@@ -235,7 +236,7 @@ public class VDMPP extends VDMJ
 				oos.close();
 				after = System.currentTimeMillis();
 
-				infoln("Saved " + plural(classes.size(), "class", "es")
+				infoln("Saved " + plural(classes.size(), CLASS, "es")
 						+ " to " + outfile + " in " + (double) (after - before)
 						/ 1000 + " secs. ");
 			} catch (IOException e)
@@ -308,7 +309,7 @@ public class VDMPP extends VDMJ
 
 			long after = System.currentTimeMillis();
 
-			infoln("Initialized " + plural(classes.size(), "class", "es")
+			infoln("Initialized " + plural(classes.size(), CLASS, "es")
 					+ " in " + (double) (after - before) / 1000 + " secs. ");
 		} catch (ContextException e)
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/commands/CommandReader.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/commands/CommandReader.java
@@ -78,6 +78,7 @@ import org.overture.pog.pub.IProofObligationList;
 
 abstract public class CommandReader
 {
+	public static final String CREATED = "Created ";
 	/** The interpreter to use for the execution of commands. */
 	protected final Interpreter interpreter;
 
@@ -1338,14 +1339,14 @@ abstract public class CommandReader
 			{
 				interpreter.clearBreakpoint(BreakpointManager.getBreakpoint(exp).number);
 				Breakpoint bp = interpreter.setBreakpoint(exp, condition);
-				println("Created " + bp);
+				println(CREATED + bp);
 				println(interpreter.getSourceLine(bp.location));
 			}
 		} else
 		{
 			interpreter.clearBreakpoint(BreakpointManager.getBreakpoint(stmt).number);
 			Breakpoint bp = interpreter.setBreakpoint(stmt, condition);
-			println("Created " + bp);
+			println(CREATED + bp);
 			println(interpreter.getSourceLine(bp.location));
 		}
 	}
@@ -1385,7 +1386,7 @@ abstract public class CommandReader
 			PExp exp = fv.body;
 			interpreter.clearBreakpoint(BreakpointManager.getBreakpoint(exp).number);
 			Breakpoint bp = interpreter.setBreakpoint(exp, condition);
-			println("Created " + bp);
+			println(CREATED + bp);
 			println(interpreter.getSourceLine(bp.location));
 		} else if (v instanceof OperationValue)
 		{
@@ -1393,7 +1394,7 @@ abstract public class CommandReader
 			PStm stmt = ov.body;
 			interpreter.clearBreakpoint(BreakpointManager.getBreakpoint(stmt).number);
 			Breakpoint bp = interpreter.setBreakpoint(stmt, condition);
-			println("Created " + bp);
+			println(CREATED + bp);
 			println(interpreter.getSourceLine(bp.location));
 		} else if (v == null)
 		{
@@ -1456,14 +1457,14 @@ abstract public class CommandReader
 			{
 				interpreter.clearBreakpoint(BreakpointManager.getBreakpoint(exp).number);
 				Breakpoint bp = interpreter.setTracepoint(exp, trace);
-				println("Created " + bp);
+				println(CREATED + bp);
 				println(interpreter.getSourceLine(bp.location));
 			}
 		} else
 		{
 			interpreter.clearBreakpoint(BreakpointManager.getBreakpoint(stmt).number);
 			Breakpoint bp = interpreter.setTracepoint(stmt, trace);
-			println("Created " + bp);
+			println(CREATED + bp);
 			println(interpreter.getSourceLine(bp.location));
 		}
 	}
@@ -1504,7 +1505,7 @@ abstract public class CommandReader
 			PExp exp = fv.body;
 			interpreter.clearBreakpoint(BreakpointManager.getBreakpoint(exp).number);
 			Breakpoint bp = interpreter.setTracepoint(exp, trace);
-			println("Created " + bp);
+			println(CREATED + bp);
 			println(interpreter.getSourceLine(bp.location));
 		} else if (v instanceof OperationValue)
 		{
@@ -1512,7 +1513,7 @@ abstract public class CommandReader
 			PStm stmt = ov.body;
 			interpreter.clearBreakpoint(BreakpointManager.getBreakpoint(stmt).number);
 			Breakpoint bp = interpreter.setTracepoint(stmt, trace);
-			println("Created " + bp);
+			println(CREATED + bp);
 			println(interpreter.getSourceLine(bp.location));
 		} else
 		{

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReader.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/DBGPReader.java
@@ -105,6 +105,7 @@ import org.overture.util.Base64;
 
 public class DBGPReader
 {
+	public static final String UTF_8 = "UTF-8";
 	protected final String host;
 	protected final int port;
 	protected final String ideKey;
@@ -651,9 +652,9 @@ public class DBGPReader
 			System.err.println("Socket to IDE not valid.");
 			return;
 		}
-		byte[] header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>".getBytes("UTF-8");
-		byte[] body = data.toString().getBytes("UTF-8");
-		byte[] size = Integer.toString(header.length + body.length).getBytes("UTF-8");
+		byte[] header = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>".getBytes(UTF_8);
+		byte[] body = data.toString().getBytes(UTF_8);
+		byte[] size = Integer.toString(header.length + body.length).getBytes(UTF_8);
 
 		output.write(size);
 		output.write(separator);
@@ -817,7 +818,7 @@ public class DBGPReader
 		sb.append(" size=\"" + value.length() + "\"");
 		sb.append(" encoding=\"base64\"");
 		sb.append("><![CDATA[");
-		sb.append(Base64.encode(value.getBytes("UTF-8")));
+		sb.append(Base64.encode(value.getBytes(UTF_8)));
 		sb.append("]]></property>");
 
 		return sb;
@@ -2201,7 +2202,7 @@ public class DBGPReader
 	public synchronized void stdout(String line) throws IOException
 	{
 		StringBuilder sb = new StringBuilder("<stream type=\"stdout\"><![CDATA[");
-		sb.append(Base64.encode(line.getBytes("UTF-8")));
+		sb.append(Base64.encode(line.getBytes(UTF_8)));
 		sb.append("]]></stream>\n");
 		write(sb);
 	}
@@ -2209,7 +2210,7 @@ public class DBGPReader
 	public synchronized void stderr(String line) throws IOException
 	{
 		StringBuilder sb = new StringBuilder("<stream type=\"stderr\"><![CDATA[");
-		sb.append(Base64.encode(line.getBytes("UTF-8")));
+		sb.append(Base64.encode(line.getBytes(UTF_8)));
 		sb.append("]]></stream>\n");
 		write(sb);
 	}

--- a/core/interpreter/src/main/java/org/overture/interpreter/debug/RemoteInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/debug/RemoteInterpreter.java
@@ -43,6 +43,7 @@ import org.overture.interpreter.values.ValueFactory;
 
 public class RemoteInterpreter
 {
+	public static final String REMOTE_INTERPRETER_HAS_FINISHED = "RemoteInterpreter has finished.";
 	private final Interpreter interpreter;
 	private final DBGPReader dbgp;
 	private boolean running = false;
@@ -73,7 +74,7 @@ public class RemoteInterpreter
 	{
 		if (isFinished)
 		{
-			throw new Exception("RemoteInterpreter has finished.");
+			throw new Exception(REMOTE_INTERPRETER_HAS_FINISHED);
 		}
 
 		executionQueueRequest.add(new Call(CallType.Execute, line));
@@ -91,7 +92,7 @@ public class RemoteInterpreter
 	{
 		if (isFinished)
 		{
-			throw new Exception("RemoteInterpreter has finished.");
+			throw new Exception(REMOTE_INTERPRETER_HAS_FINISHED);
 		}
 
 		executionQueueRequest.add(new Call(CallType.Execute, line));
@@ -114,7 +115,7 @@ public class RemoteInterpreter
 	{
 		if (isFinished)
 		{
-			throw new Exception("RemoteInterpreter has finished.");
+			throw new Exception(REMOTE_INTERPRETER_HAS_FINISHED);
 		}
 
 		if (interpreter instanceof ClassInterpreter)

--- a/core/interpreter/src/main/java/org/overture/interpreter/eval/ExpressionEvaluator.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/eval/ExpressionEvaluator.java
@@ -123,6 +123,8 @@ import org.overture.typechecker.assistant.pattern.PatternListTC;
 public class ExpressionEvaluator extends BinaryExpressionEvaluator
 {
 
+	public static final String EXPRESSION = "expression";
+
 	@Override
 	public Value caseAApplyExp(AApplyExp node, Context ctxt)
 			throws AnalysisException
@@ -817,7 +819,7 @@ public class ExpressionEvaluator extends BinaryExpressionEvaluator
 	public Value caseALetBeStExp(ALetBeStExp node, Context ctxt)
 			throws AnalysisException
 	{
-		return evalLetBeSt(node, node.getLocation(), node.getDef(), node.getSuchThat(), node.getValue(), 4015, "expression", ctxt);
+		return evalLetBeSt(node, node.getLocation(), node.getDef(), node.getSuchThat(), node.getValue(), 4015, EXPRESSION, ctxt);
 	}
 
 	public Value evalLetBeSt(INode node, ILexLocation nodeLocation,
@@ -885,7 +887,7 @@ public class ExpressionEvaluator extends BinaryExpressionEvaluator
 	public Value caseALetDefExp(ALetDefExp node, Context ctxt)
 			throws AnalysisException
 	{
-		return evalLet(node, node.getLocation(), node.getLocalDefs(), node.getExpression(), "expression", ctxt);
+		return evalLet(node, node.getLocation(), node.getLocalDefs(), node.getExpression(), EXPRESSION, ctxt);
 	}
 
 	public Value evalLet(INode node, ILexLocation nodeLocation,
@@ -1193,7 +1195,7 @@ public class ExpressionEvaluator extends BinaryExpressionEvaluator
 	public Value caseANotYetSpecifiedExp(ANotYetSpecifiedExp node, Context ctxt)
 			throws AnalysisException
 	{
-		return evalANotYetSpecified(node, node.getLocation(), 4024, "expression", ctxt);
+		return evalANotYetSpecified(node, node.getLocation(), 4024, EXPRESSION, ctxt);
 	}
 
 	protected Value evalANotYetSpecified(INode node, ILexLocation location,


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1192 - “String literals should not be duplicated”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1192
Please let me know if you have any questions.
Ayman Abdelghany.
