### PR TITLE
Constant names should comply with a naming convention

### DIFF
--- a/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/MATH.java
+++ b/core/codegen/codegen-runtime/src/main/java/org/overture/codegen/runtime/MATH.java
@@ -26,7 +26,7 @@ import java.util.Random;
 public class MATH
 {
 
-	public static final Number pi = 3.141592653589793;
+	public static final Number PI = 3.141592653589793;
 	private static Random random = new Random();
 	private static long seed = 0;
 	

--- a/core/isapog/src/test/java/org/overture/isapog/ThyWriteTest.java
+++ b/core/isapog/src/test/java/org/overture/isapog/ThyWriteTest.java
@@ -16,22 +16,22 @@ import org.overture.core.tests.ParseTcFacade;
 
 public class ThyWriteTest {
 
-    private static final String modelPath = "src/test/resources/thywrite/model.vdmsl";
-    private static final String thysPath = "src/test/resources/thywrite/";
+    private static final String MODEL_PATH = "src/test/resources/thywrite/model.vdmsl";
+    private static final String THYS_PATH = "src/test/resources/thywrite/";
 
-    private static final String modelThy = thysPath + "DEFAULT.thy";
-    private static final String posThy = thysPath + "DEFAULT_POs.thy";
+    private static final String MODEL_THY = THYS_PATH + "DEFAULT.thy";
+    private static final String POS_THY = THYS_PATH + "DEFAULT_POs.thy";
 
     @Test
     public void fileWriteTest() throws IOException, AnalysisException,
             org.overture.codegen.ir.analysis.AnalysisException {
-        List<INode> ast = ParseTcFacade.typedAst(modelPath, "ThyWrite");
+        List<INode> ast = ParseTcFacade.typedAst(MODEL_PATH, "ThyWrite");
 
         IsaPog isapo = new IsaPog(ast);
-        isapo.writeThyFiles(thysPath);
+        isapo.writeThyFiles(THYS_PATH);
 
-        File modelFile = new File(modelThy);
-        File posFile = new File(posThy);
+        File modelFile = new File(MODEL_THY);
+        File posFile = new File(POS_THY);
 
         assertNotNull(modelFile);
         assertNotNull(posFile);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S00115 - “Constant names should comply with a naming convention”. 
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S00115
Please let me know if you have any questions.
Ayman Abdelghany.
