### PR TITLE
Kel/vdmsl test lib

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,7 @@ node {
     try
     {
         // Only keep one build
-        properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '1']]])
+        properties([[$class: 'BuildDiscarderProperty', strategy: [$class: 'LogRotator', numToKeepStr: '25']]])
         
         // Mark the code checkout 'stage'....
         stage ('Checkout'){

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,10 +52,6 @@ node {
         throw any //rethrow exception to prevent the build from proceeding
     } finally {
 
-        stage ('Clean up workspace'){
-            step([$class: 'WsCleanup'])
-        }
-
         stage('Reporting'){
             // Notify on build failure using the Email-ext plugin
             emailext(body: '${DEFAULT_CONTENT}', mimeType: 'text/html',

--- a/core/interpreter/src/main/java/TestCase.java
+++ b/core/interpreter/src/main/java/TestCase.java
@@ -90,10 +90,11 @@ public class TestCase {
         try {
             ModuleInterpreter.getInstance().evaluate(moduleName + "`" + testName + "()"
                     , ModuleInterpreter.getInstance().initialContext);
-            success = true;
+            success = !TestRunner.isFailed();
         } catch (Exception e) {
+            success = false;
             if (e instanceof ExitException) {
-                success = false;
+                error = (ExitException) e;
             }
             throw e;
         } finally {
@@ -166,6 +167,10 @@ public class TestCase {
                 failureElement.setAttribute("message", methodName);
                 failureElement.setAttribute("type", "WARNING");
                 failureElement.setAttribute("time", totalExecTime * 1E-9 + "");
+                if(TestRunner.getMsg()!=null)
+                {
+                    failureElement.setTextContent(TestRunner.getMsg());
+                }
                 n.appendChild(failureElement);
             }
 

--- a/core/interpreter/src/main/java/TestCase.java
+++ b/core/interpreter/src/main/java/TestCase.java
@@ -86,16 +86,14 @@ public class TestCase {
 
         long timerStart = System.nanoTime();
         boolean success = false;
-        ExitException error = null;
+        Exception error = null;
         try {
             ModuleInterpreter.getInstance().evaluate(moduleName + "`" + testName + "()"
                     , ModuleInterpreter.getInstance().initialContext);
             success = !TestRunner.isFailed();
         } catch (Exception e) {
             success = false;
-            if (e instanceof ExitException) {
-                error = (ExitException) e;
-            }
+            error =  e;
             throw e;
         } finally {
             long totalExecTime = System.nanoTime() - timerStart;
@@ -107,7 +105,20 @@ public class TestCase {
         return success;
     }
 
-    private static void recordTestResults(String containerName, String methodName, boolean success, ExitException error, long totalExecTime) throws ParserConfigurationException, IOException, SAXException, XPathExpressionException, TransformerException {
+
+    public static void reflectionRun(AModuleModules module, AExplicitOperationDefinition opDef) {
+        String moduleName = module.getName().getName();
+        String testName = opDef.getName().getName();
+
+        try {
+            ModuleInterpreter.getInstance().evaluate(moduleName + "`" + testName + "()"
+                    , ModuleInterpreter.getInstance().initialContext);
+        } catch (Exception e) {
+            // Fine
+        }
+    }
+
+    private static void recordTestResults(String containerName, String methodName, boolean success, Exception error, long totalExecTime) throws ParserConfigurationException, IOException, SAXException, XPathExpressionException, TransformerException {
 
         File report = new File("TEST-" + containerName + ".xml");
 
@@ -158,7 +169,12 @@ public class TestCase {
                 errorElement.setAttribute("message", error.getMessage() + "");
                 errorElement.setAttribute("type", "ERROR");
                 StringWriter strOut = new StringWriter();
-                error.ctxt.printStackTrace(new PrintWriter(strOut), true);
+                if(error instanceof  ExitException) {
+                    ((ExitException)error).ctxt.printStackTrace(new PrintWriter(strOut), true);
+                }else
+                {
+                    error.printStackTrace(new PrintWriter(strOut));
+                }
                 errorElement.setTextContent(strOut.toString());
                 n.appendChild(errorElement);
             } else if (!success) {

--- a/core/interpreter/src/main/java/TestCase.java
+++ b/core/interpreter/src/main/java/TestCase.java
@@ -155,7 +155,7 @@ public class TestCase {
             if (error != null) {
                 testSuiteNode.setAttribute("error", String.valueOf(Integer.parseInt(testSuiteNode.getAttribute("errors")) + 1));
                 Element errorElement = doc.createElement("error");
-                errorElement.setAttribute("message", error.number + "");
+                errorElement.setAttribute("message", error.getMessage() + "");
                 errorElement.setAttribute("type", "ERROR");
                 StringWriter strOut = new StringWriter();
                 error.ctxt.printStackTrace(new PrintWriter(strOut), true);

--- a/core/interpreter/src/main/java/TestRunner.java
+++ b/core/interpreter/src/main/java/TestRunner.java
@@ -1,90 +1,136 @@
+import org.overture.ast.definitions.AExplicitOperationDefinition;
+import org.overture.ast.definitions.PDefinition;
+import org.overture.ast.definitions.SClassDefinition;
+import org.overture.ast.modules.AModuleModules;
+import org.overture.interpreter.messages.Console;
+import org.overture.interpreter.runtime.*;
+import org.overture.interpreter.values.*;
+
 import java.util.List;
 import java.util.Vector;
 
-import org.overture.ast.definitions.SClassDefinition;
-import org.overture.interpreter.runtime.*;
-import org.overture.interpreter.values.ObjectValue;
-import org.overture.interpreter.values.SetValue;
-import org.overture.interpreter.values.Value;
-import org.overture.interpreter.values.ValueSet;
+public class TestRunner {
+    public static Value collectTests(Value obj) {
+        List<String> tests = new Vector<String>();
+        ObjectValue instance = (ObjectValue) obj;
 
-public class TestRunner
-{
-	public static Value collectTests(Value obj)
-	{
-		List<String> tests = new Vector<String>();
-		ObjectValue instance = (ObjectValue) obj;
+        if (ClassInterpreter.getInstance() instanceof ClassInterpreter) {
+            for (SClassDefinition def : ((ClassInterpreter) ClassInterpreter.getInstance()).getClasses()) {
+                if (def.getIsAbstract() || !isTestClass(def)) {
+                    continue;
+                }
+                tests.add(def.getName().getName());
+            }
+        }
 
-		if (ClassInterpreter.getInstance() instanceof ClassInterpreter)
-		{
-			for (SClassDefinition def : ((ClassInterpreter) ClassInterpreter.getInstance()).getClasses())
-			{
-				if (def.getIsAbstract() || !isTestClass(def))
-				{
-					continue;
-				}
-				tests.add(def.getName().getName());
-			}
-		}
+        Context mainContext = new StateContext(Interpreter.getInstance().getAssistantFactory(), instance.type.getLocation(), "reflection scope");
 
-		Context mainContext = new StateContext(Interpreter.getInstance().getAssistantFactory(), instance.type.getLocation(), "reflection scope");
+        mainContext.putAll(ClassInterpreter.getInstance().initialContext);
+        mainContext.setThreadState(ClassInterpreter.getInstance().initialContext.threadState.dbgp, ClassInterpreter.getInstance().initialContext.threadState.CPU);
 
-		mainContext.putAll(ClassInterpreter.getInstance().initialContext);
-		mainContext.setThreadState(ClassInterpreter.getInstance().initialContext.threadState.dbgp, ClassInterpreter.getInstance().initialContext.threadState.CPU);
+        ValueSet vals = new ValueSet();
+        for (String value : tests) {
+            try {
+                vals.add(ClassInterpreter.getInstance().evaluate("new " + value
+                        + "()", mainContext));
+            } catch (Exception e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
 
-		ValueSet vals = new ValueSet();
-		for (String value : tests)
-		{
-			try
-			{
-				vals.add(ClassInterpreter.getInstance().evaluate("new " + value
-						+ "()", mainContext));
-			} catch (Exception e)
-			{
-				// TODO Auto-generated catch block
-				e.printStackTrace();
-			}
-		}
+        try {
+            return new SetValue(vals);
+        } catch (ValueException e) {
+            return null;    // Not reached
+        }
+    }
 
-		try
-		{
-			return new SetValue(vals);
-		}
-		catch (ValueException e)
-		{
-			return null;	// Not reached
-		}
-	}
+    private static boolean isTestClass(SClassDefinition def) {
+        if (def.getIsAbstract() || def.getName().getName().equals("Test")
+                || def.getName().getName().equals("TestCase")
+                || def.getName().getName().equals("TestSuite")) {
+            return false;
+        }
 
-	private static boolean isTestClass(SClassDefinition def)
-	{
-		if (def.getIsAbstract() || def.getName().getName().equals("Test")
-				|| def.getName().getName().equals("TestCase")
-				|| def.getName().getName().equals("TestSuite"))
-		{
-			return false;
-		}
+        if (checkForSuper(def, "TestSuite")) {
+            // the implementation must be upgrade before this work.
+            // The upgrade should handle the static method for creatint the suire
+            return false;
+        }
 
-		if (checkForSuper(def, "TestSuite"))
-		{
-			// the implementation must be upgrade before this work.
-			// The upgrade should handle the static method for creatint the suire
-			return false;
-		}
+        return checkForSuper(def, "Test");
+    }
 
-		return checkForSuper(def, "Test");
-	}
+    private static boolean checkForSuper(SClassDefinition def, String superName) {
+        for (SClassDefinition superDef : def.getSuperDefs()) {
+            if (superDef.getName().getName().equals(superName)
+                    || checkForSuper(superDef, superName)) {
+                return true;
+            }
+        }
+        return false;
+    }
 
-	private static boolean checkForSuper(SClassDefinition def, String superName)
-	{
-		for (SClassDefinition superDef : def.getSuperDefs())
-		{
-			if (superDef.getName().getName().equals(superName)
-					|| checkForSuper(superDef, superName))
-			{
-				return true;
-			}
-		}
-		return false;
-	}
+
+    public static Value run() {
+        //lets find the modules
+        List<AModuleModules> tests = new Vector<>();
+
+        if (ModuleInterpreter.getInstance() instanceof ModuleInterpreter) {
+            for (AModuleModules def : ((ModuleInterpreter) ModuleInterpreter.getInstance()).getModules()) {
+                if (!def.getName().getName().endsWith("Test")) {
+                    continue;
+                }
+                tests.add(def);
+            }
+        }
+
+        int testCount = 0;
+        int testFailCount = 0;
+        int testErrorCount = 0;
+
+        for (AModuleModules module : tests) {
+            String moduleName = module.getName().getName();
+            for (PDefinition def : module.getDefs()) {
+
+                String testName = def.getName().getName();
+                if (def instanceof AExplicitOperationDefinition && testName.startsWith("test")) {
+                    try {
+                        testCount++;
+                        Console.out.println("Executing test: " + moduleName + "`" + testName + "()");
+                        if (TestCase.reflectionRunTest(module, (AExplicitOperationDefinition) def)) {
+                            Console.out.println("\tOK");
+                        } else {
+                            testFailCount++;
+                            Console.out.println("\tFAIL");
+                        }
+                    } catch (Exception e) {
+                        testErrorCount++;
+                        Console.out.println("\tERROR");
+                    }
+                }
+            }
+        }
+
+        String header = "----------------------------------------\n" +
+                "|    TEST RESULTS                      |\n" +
+                "|--------------------------------------|";
+        Console.out.println(header);
+        Console.out.println(String.format("| Executed: %1$-" + 27 + "s", testCount) + "|");
+        Console.out.println(String.format("| Failures: %1$-" + 27 + "s", testFailCount) + "|");
+        Console.out.println(String.format("| Errors  : %1$-" + 27 + "s", testErrorCount) + "|");
+        Console.out.println("|______________________________________|");
+
+
+        if (testErrorCount == 0 && testFailCount == 0) {
+            Console.out.println("|              SUCCESS                 |");
+        } else {
+            Console.out.println("|              FAILURE                 |");
+        }
+        Console.out.println("|______________________________________|\n");
+
+
+        return new VoidValue();
+    }
 }

--- a/core/interpreter/src/main/java/TestRunner.java
+++ b/core/interpreter/src/main/java/TestRunner.java
@@ -10,6 +10,31 @@ import java.util.List;
 import java.util.Vector;
 
 public class TestRunner {
+	
+	private static boolean fail = false;
+	private static String msg = null;
+	
+	public static Value markFail()
+	{
+		fail = true;
+		return new VoidValue();
+	}
+	
+	public static Value setMsg(Value msgVal)
+	{
+		if(msgVal instanceof SeqValue)
+		{
+			try {
+				msg = msgVal.stringValue(null);
+			} catch (ValueException e) {
+				
+				Console.out.println("\tReceived unexpected message: " + msgVal);
+			}
+		}
+		
+		return new VoidValue();
+	}
+	
     public static Value collectTests(Value obj) {
         List<String> tests = new Vector<String>();
         ObjectValue instance = (ObjectValue) obj;
@@ -91,19 +116,37 @@ public class TestRunner {
         int testErrorCount = 0;
 
         for (AModuleModules module : tests) {
+        	        	
             String moduleName = module.getName().getName();
             for (PDefinition def : module.getDefs()) {
 
                 String testName = def.getName().getName();
                 if (def instanceof AExplicitOperationDefinition && testName.startsWith("test")) {
+                	
+                	fail = false;
+                	msg = null;
+                	
                     try {
                         testCount++;
                         Console.out.println("Executing test: " + moduleName + "`" + testName + "()");
-                        if (TestCase.reflectionRunTest(module, (AExplicitOperationDefinition) def)) {
-                            Console.out.println("\tOK");
-                        } else {
+                        
+                        TestCase.reflectionRunTest(module, (AExplicitOperationDefinition) def);
+                        
+                        if(fail)
+                        {
                             testFailCount++;
-                            Console.out.println("\tFAIL");
+                            //TODO: is this the right format?
+                            if(msg != null)
+                            {
+                            	Console.out.println("\tFAIL: " + msg);
+                            }
+                            else
+                            {                            	
+                            	Console.out.println("\tFAIL");
+                            }
+                        }
+                        else {
+                        	Console.out.println("\tOK");
                         }
                     } catch (Exception e) {
                         testErrorCount++;

--- a/core/interpreter/src/main/java/TestRunner.java
+++ b/core/interpreter/src/main/java/TestRunner.java
@@ -147,7 +147,7 @@ public class TestRunner {
                         
                         if(setup != null)
                         {
-                        	TestCase.reflectionRunTest(module, setup);
+                        	TestCase.reflectionRun(module, setup);
                         }
                         
                         TestCase.reflectionRunTest(module, (AExplicitOperationDefinition) def);
@@ -156,7 +156,7 @@ public class TestRunner {
                         
                         if(tearDown != null)
                         {
-                        	TestCase.reflectionRunTest(module, tearDown);
+                        	TestCase.reflectionRun(module, tearDown);
                         }
                         
                         if(fail)
@@ -177,7 +177,7 @@ public class TestRunner {
                         }
                     } catch (Exception e) {
                         testErrorCount++;
-                        Console.out.println("\tERROR");
+                        Console.out.println("\tERROR: "+e.getMessage());
                     }
 					finally
 					{
@@ -187,7 +187,7 @@ public class TestRunner {
 							{
 								try
 								{
-									TestCase.reflectionRunTest(module, tearDown);
+									TestCase.reflectionRun(module, tearDown);
 								} catch (Exception e)
 								{
 									e.printStackTrace();

--- a/core/interpreter/src/main/java/TestRunner.java
+++ b/core/interpreter/src/main/java/TestRunner.java
@@ -20,6 +20,11 @@ public class TestRunner {
 		fail = true;
 		return new VoidValue();
 	}
+
+	public static boolean isFailed()
+    {
+        return fail;
+    }
 	
 	public static Value setMsg(Value msgVal)
 	{
@@ -35,6 +40,11 @@ public class TestRunner {
 		
 		return new VoidValue();
 	}
+
+	public static String getMsg()
+    {
+        return msg;
+    }
 	
     public static Value collectTests(Value obj) {
         List<String> tests = new Vector<String>();
@@ -184,6 +194,8 @@ public class TestRunner {
 								}
 							}
 						}
+						msg = null;
+                        fail = false;
 					}
                 }
             }

--- a/core/interpreter/src/main/java/TestRunner.java
+++ b/core/interpreter/src/main/java/TestRunner.java
@@ -124,9 +124,8 @@ public class TestRunner {
             String moduleName = module.getName().getName();
             for (PDefinition def : module.getDefs()) {
 
-                String testName = def.getName().getName();
-                if (def instanceof AExplicitOperationDefinition && testName.startsWith("test")) {
-                	
+                if (def instanceof AExplicitOperationDefinition && def.getName().getName().startsWith("test")) {
+
                 	fail = false;
                 	msg = null;
                 	
@@ -134,7 +133,7 @@ public class TestRunner {
                 	
                     try {
                         testCount++;
-                        Console.out.println("Executing test: " + moduleName + "`" + testName + "()");
+                        Console.out.println("Executing test: " + moduleName + "`" + def.getName().getName() + "()");
                         
                         if(setup != null)
                         {


### PR DESCRIPTION
Library for testing sl models using VDMUnit for sl

Library:

```
module TestRunner
exports all
definitions

operations

run : ()==>()
run()== is not yet specified;

markFail : () ==> ()
markFail () == is not yet specified;

setMsg : seq of char ==> ()
setMsg (msg) == is not yet specified;

end TestRunner


module Assert

imports from TestRunner all
exports all
definitions
operations
assertTrue: bool ==> ()
assertTrue (pbool) ==
  if not pbool then
    TestRunner`markFail();

assertTrueMsg: seq of char * bool ==> ()
assertTrueMsg (pmessage, pbool) ==
  if not pbool then
  (
    TestRunner`markFail();
    TestRunner`setMsg(pmessage);
  );

assertFalse: bool ==> ()
assertFalse (pbool) ==
  if pbool then
    TestRunner`markFail();

assertFalseMsg: seq of char * bool ==> ()
assertFalseMsg (pmessage, pbool) ==
   if pbool then
  (
    TestRunner`markFail();
    TestRunner`setMsg(pmessage);
  );

fail: () ==> ()
fail () == is not yet specified;

failMsg: seq of char ==> ()
failMsg (pmessage) == is not yet specified;

end Assert
```

test example:

```
module MyTest
imports from IO all
exports all definitions
operations
testError: ()==>()
testError()==(IO`println("Running MyTest`testError."); exit; IO`println("Continuing."));

test1Success: ()==>()
test1Success()==(IO`println("Running MyTest`test1Success."); skip; IO`println("Continuing."));

test2Error: ()==>()
test2Error()==(IO`println("Running MyTest`test1Success."); exit; IO`println("Continuing."));
end MyTest


module My2Test
imports from IO all,
       from Assert all
exports all
definitions
operations

setUp : () ==> ()
setUp () == IO`println("In setUp");

tearDown : () ==> ()
tearDown () == IO`println("In tearDown");

testSuccess: ()==>()
testSuccess()==(IO`println("Running My2Test`test."); skip; IO`println("Continuing."));

test1Success: ()==>()
test1Success()==(IO`println("Running My2Test`test1."); skip; IO`println("Continuing."));

test2Error: ()==>()
test2Error()==(IO`println("Running My2Test`test2."); exit; IO`println("Continuing."));

test3Success: ()==>()
test3Success()==(IO`println("Running My2Test`test3.."); skip; IO`println("Continuing."));

test4Fail: ()==>()
test4Fail()==(IO`println("Running My2Test`test4.."); Assert`assertTrueMsg("Expected failure", false); IO`println("Continuing."));

test5Success: ()==>()
test5Success()==(IO`println("Running My2Test`test5.."); Assert`assertTrueMsg("Not expecting failure", true); IO`println("Continuing."));

end My2Test
```

if execute with `-Dvdm.unit.report` then junit reports for CI is also generated, example: 

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" errors="0" failures="0" name="Mqttest" skipped="0" tests="1" time="14.856560025" xsi:schemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd">
  <testcase classname="MqttRouteTest" name="test" time="14.856560025"/>
</testsuite>
```

```xml
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<testsuite xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" error="1" errors="0" failures="0" name="BeeTest" skipped="0" tests="3" time="0.04333706700000001" xsi:schemaLocation="https://maven.apache.org/surefire/maven-surefire-plugin/xsd/surefire-test-report.xsd">
  <testcase classname="BTest" name="test_abc" time="0.016850875">
    <error message="Error 4129: Exit &quot;... file.vdmsl) at line 90:17" type="ERROR">	harvMin = 36000
stack trace vdm
</error>
  </testcase>
 </testsuite>
```