### PR TITLE
Removed location from ADefPatternBind.toString()

### DIFF
--- a/core/ast/src/main/resources/overtureII.astv2.tostring
+++ b/core/ast/src/main/resources/overtureII.astv2.tostring
@@ -147,6 +147,8 @@ import org.overture.ast.util.ToStringUtil;
 %pattern->map = "" + $($[maplets]$.isEmpty() ? "{|->}" : Utils.listToString("{", $[maplets]$, ", ", "}"))$
 %pattern->object = "obj_" [classname]  "(" + $Utils.listToString($[fields]$)$ + ")"
 
+%patternBind->def = "pattern=" [pattern] ", bind=" [bind] ", defs=(" + $Utils.listToString($[defs]$)$ + "), type=" [type]
+
   
 
 //  Definitions


### PR DESCRIPTION
The location field includes the filename which -- as equals() uses toString() -- means that two specs from different files that contain this node can never be equal. Have explicitly specified the toString() pattern for this node such that this member is omitted.