### PR TITLE
Fixed typo in VDM++ new class template

### DIFF
--- a/ide/vdmpp/ui/src/main/java/org/overture/ide/vdmpp/ui/wizard/VdmPpNewClassWizard.java
+++ b/ide/vdmpp/ui/src/main/java/org/overture/ide/vdmpp/ui/wizard/VdmPpNewClassWizard.java
@@ -52,7 +52,7 @@ public class VdmPpNewClassWizard extends VdmNewFileWizard {
 		String className = fileName;
 		return "class " + className + "\n" + "types\n-- TODO Define types here\n"
 				+ "values\n-- TODO Define values here\n" + "instance variables\n-- TODO Define instance variables here\n"
-				+ "operations\n-- TODO Define operations here\n" + "functions\n-- TODO Define functiones here\n" 
+				+ "operations\n-- TODO Define operations here\n" + "functions\n-- TODO Define functions here\n"
 				+ "traces\n-- TODO Define Combinatorial Test Traces here\n" + "end "
 				+ className;
 	}


### PR DESCRIPTION
Fixed typo on comments of new class template.
Previously was as follows:
<img width="397" alt="screenshot 2018-12-29 at 13 19 04" src="https://user-images.githubusercontent.com/13498941/50538755-53188480-0b6c-11e9-9073-1a461fabc55e.png">
