### PR TITLE
Corrected retrieval of nat values to allow 0

### DIFF
--- a/core/interpreter/src/main/java/org/overture/interpreter/values/ReferenceValue.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/values/ReferenceValue.java
@@ -104,7 +104,7 @@ abstract public class ReferenceValue extends Value
 	@Override
 	public long natValue(Context ctxt) throws ValueException
 	{
-		return value.nat1Value(ctxt);
+		return value.natValue(ctxt);
 	}
 
 	@Override


### PR DESCRIPTION
When fetching a `nat` value from a `ReferenceValue`, 0 causes an exception as the call is incorrectly delegated to the `nat1Value` method of the referenced value. This PR updates the class to delegates to the `natValue` method of the referenced value.