### PR TITLE
Removed hard limit on module initialization

### DIFF
--- a/core/interpreter/src/main/java/org/overture/interpreter/assistant/module/ModuleListAssistantInterpreter.java
+++ b/core/interpreter/src/main/java/org/overture/interpreter/assistant/module/ModuleListAssistantInterpreter.java
@@ -48,12 +48,14 @@ public class ModuleListAssistantInterpreter
 	{
 		StateContext initialContext = (StateContext) ctxt;
 		initialContext.setThreadState(dbgp, null);
-		Set<ContextException> problems = null;
-		int retries = 5;
+		Set<ContextException> problems = new HashSet<ContextException>();
 
+		int lastProblemCount;
 		do
 		{
-			problems = new HashSet<ContextException>();
+			lastProblemCount = problems.isEmpty() ? Integer.MAX_VALUE : problems.size();
+			problems.clear();
+
 
 			for (AModuleModules m : modules)
 			{
@@ -70,7 +72,7 @@ public class ModuleListAssistantInterpreter
         			}
 				}
 			}
-		} while (--retries > 0 && !problems.isEmpty());
+		} while (problems.size() < lastProblemCount && !problems.isEmpty());
 
 		if (!problems.isEmpty())
 		{


### PR DESCRIPTION
With a large number of VDM-SL modules (200+) with mutual dependencies we have been hitting an issue whereby the specification would parse and type check fine, but would then hit scope issues when initialising for animation.

With a bit of digging, we discovered a hard limit that we were hitting despite having a resolvable scenario. Rather than just increasing the limit, we added a problem count and allowed the initialisation to continue as long as that problem count decreased on each pass.

I have not been able to devise a mechanism to force a unit test that would have failed but now passes, but this certainly removes the blocker in our large project with failures occurring when expected. All existing tests continue to pass.

There may well be a better solution than the one proposed here, but this fix enabled us to proceed with our project using a patched tool.